### PR TITLE
HTML report now always shows Trust Policies for Roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.0.9 (2020-05-03)
+* HTML report now always shows Trust Policies for Roles, even if they do not allow assumption from a Compute Service. This can help assessors with triaging and pentesters for targeting.
+
 ## 0.0.8 (2020-05-03)
 * Migrated to GitHub actions with automated Homebrew releases
 

--- a/cloudsplaining/bin/cloudsplaining
+++ b/cloudsplaining/bin/cloudsplaining
@@ -7,7 +7,7 @@
 """
     Cloudsplaining is an AWS IAM Assessment tool that identifies violations of least privilege and generates a risk-prioritized HTML report with a triage worksheet.
 """
-__version__ = "0.0.8"
+__version__ = "0.0.9"
 import click
 from cloudsplaining import command
 

--- a/cloudsplaining/output/templates/analysis/customer-managed.html
+++ b/cloudsplaining/output/templates/analysis/customer-managed.html
@@ -32,7 +32,7 @@
         </div>
       </div>
      <!--Trust Policy Document-->
-      {% if finding["AssumableByComputeService"]|length > 0 %}
+      {% if finding["Type"] == "Role" %}
         <div class="card">
            <div class="card-header">
               <a class="card-link" data-toggle="collapse" data-parent="#card-customer-{{ t['results'].index(finding) }}" href="#card-element-customer-trust-policy{{ t['results'].index(finding) }}">Trust Policy Document</a>

--- a/examples/files/iam-report-example.html
+++ b/examples/files/iam-report-example.html
@@ -540,6 +540,30 @@
       </div>
      <!--Trust Policy Document-->
       
+        <div class="card">
+           <div class="card-header">
+              <a class="card-link" data-toggle="collapse" data-parent="#card-customer-16" href="#card-element-customer-trust-policy16">Trust Policy Document</a>
+           </div>
+           <div id="card-element-customer-trust-policy16" class="panel-collapse collapse">
+            <div class="card-body">
+              <pre><code>
+{
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ssm.amazonaws.com"
+            }
+        }
+    ],
+    "Version": "2012-10-17"
+}
+              </code></pre>
+            </div>
+           </div>
+        </div>
+      
      <!--/end Trust Policy Document-->
       
       <!--High Priority Risks-->

--- a/index.html
+++ b/index.html
@@ -540,6 +540,30 @@
       </div>
      <!--Trust Policy Document-->
       
+        <div class="card">
+           <div class="card-header">
+              <a class="card-link" data-toggle="collapse" data-parent="#card-customer-16" href="#card-element-customer-trust-policy16">Trust Policy Document</a>
+           </div>
+           <div id="card-element-customer-trust-policy16" class="panel-collapse collapse">
+            <div class="card-body">
+              <pre><code>
+{
+    "Statement": [
+        {
+            "Action": "sts:AssumeRole",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "ssm.amazonaws.com"
+            }
+        }
+    ],
+    "Version": "2012-10-17"
+}
+              </code></pre>
+            </div>
+           </div>
+        </div>
+      
      <!--/end Trust Policy Document-->
       
       <!--High Priority Risks-->


### PR DESCRIPTION
* HTML report now always shows Trust Policies for Roles, even if they do not allow assumption from a Compute Service. This can help assessors with triaging and pentesters for targeting. Fixes #15 

Bumping to a new version in anticipation of Tuesday morning announcement