### PR TITLE
Fix credentials loading for download command. Set required minimum Policy Sentry version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ default-iam-report.csv
 private/default-iam-results.json
 default-results-summary.csv
 private/*
+current.json
 
 Pipfile.lock
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## 0.0.10 (2020-05-05)
+* Removed the recursive credentials method from the `download` command.
+* Fixed occasional installation error occurring from outdated Policy Sentry versions.
+* Fixed instructions for the `download` command.
+
 ## 0.0.9 (2020-05-03)
 * HTML report now always shows Trust Policies for Roles, even if they do not allow assumption from a Compute Service. This can help assessors with triaging and pentesters for targeting.
 

--- a/README.md
+++ b/README.md
@@ -101,16 +101,11 @@ pip3 install --user cloudsplaining
 
 We can scan an entire AWS account and generate reports. To do this, we leverage the AWS IAM [get-account-authorization-details](https://docs.aws.amazon.com/cli/latest/reference/iam/get-account-authorization-details.html) API call, which downloads a large JSON file (around 100KB per account) that contains all of the IAM details for the account. This includes data on users, groups, roles, customer-managed policies, and AWS-managed policies.
 
-* To do this, set your AWS access keys as environment variables:
+* You must have AWS credentials configured that can be used by the CLI.
 
-```bash
-export AWS_ACCESS_KEY_ID=...
-export AWS_SECRET_ACCESS_KEY=...
-# If you are using MFA or STS; optional but highly recommended
-export AWS_SESSION_TOKEN=...
-```
+* You must have the privileges to run [iam:GetAccountAuthorizationDetails](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetAccountAuthorizationDetails.html). The `arn:aws:iam::aws:policy/SecurityAudit` policy includes this, as do many others that allow Read access to the IAM Service.
 
-* Then run `cloudsplaining`'s `download` command:
+* To download the account authorization details, ensure you are authenticated to AWS, then run `cloudsplaining`'s `download` command:
 
 ```bash
 cloudsplaining download
@@ -119,10 +114,10 @@ cloudsplaining download
 * If you prefer to use your `~/.aws/credentials` file instead of environment variables, you can specify the profile name:
 
 ```bash
-cloudsplaining download --profile default
+cloudsplaining download --profile myprofile
 ```
 
-It will download a file titled `default.json` in your current directory.
+It will download a JSON file in your current directory that contains your account authorization detail information.
 
 #### Create Exclusions file
 
@@ -302,13 +297,17 @@ No, it will only scan policies that are attached to IAM principals.
 
 Not by default. If you want to do this, specify the `--include-non-default-policy-versions` flag. Note that the `scan` tool does not currently operate on non-default versions.
 
-**I followed the installation instructions but can't execute the program via command line. What do I do?**
+**I followed the installation instructions but can't execute the program via command line at all. What do I do?**
 
 This is likely an issue with your PATH. Your PATH environment variable is not considering the binary packages installed by `pip3`. On a Mac, you can likely fix this by entering the command below, depending on the versions you have installed. YMMV.
 
 ```bash
 export PATH=$HOME/Library/Python/3.7/bin/:$PATH
 ```
+
+**I followed the installation instructions but I am receiving a `ModuleNotFoundError` that says `No module named policy_sentry.analysis.expand`. What should I do?**
+
+Try upgrading to the latest version of Cloudsplaining. This error was fixed in version 0.0.10.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -274,8 +274,6 @@ Actions: ecr:BatchDeleteImage, ecr:CompleteLayerUpload, ecr:CreateRepository, ec
 cloudsplaining download
 # Download from a specific profile
 cloudsplaining download --profile someprofile
-# Download authorization details for **all** of your AWS profiles
-cloudsplaining download --profile all
 
 # Scan Authorization details
 cloudsplaining scan --input default.json

--- a/cloudsplaining/bin/cloudsplaining
+++ b/cloudsplaining/bin/cloudsplaining
@@ -7,7 +7,7 @@
 """
     Cloudsplaining is an AWS IAM Assessment tool that identifies violations of least privilege and generates a risk-prioritized HTML report with a triage worksheet.
 """
-__version__ = "0.0.9"
+__version__ = "0.0.10"
 import click
 from cloudsplaining import command
 

--- a/cloudsplaining/command/download.py
+++ b/cloudsplaining/command/download.py
@@ -8,7 +8,6 @@ account-alias.json """
 import os
 import json
 import logging
-import configparser
 from pathlib import Path
 import boto3
 import click
@@ -122,4 +121,3 @@ def download(profile, output, include_non_default_policy_versions):
         json.dump(results, file, indent=4, default=str)
         print(f"Saved results to {output_filename}")
     return 1
-

--- a/docs/user-guide/download.md
+++ b/docs/user-guide/download.md
@@ -1,37 +1,26 @@
-# Downloading Account Authorization Details
+#### Downloading Account Authorization Details
 
-The `download` command downloads a large JSON file containing all the AWS IAM information in your account. This is done via the [aws iam get-account-authorization-details](https://docs.aws.amazon.com/cli/latest/reference/iam/get-account-authorization-details.html) API call. It stores them in `account-alias.json`.
+We can scan an entire AWS account and generate reports. To do this, we leverage the AWS IAM [get-account-authorization-details](https://docs.aws.amazon.com/cli/latest/reference/iam/get-account-authorization-details.html) API call, which downloads a large JSON file (around 100KB per account) that contains all of the IAM details for the account. This includes data on users, groups, roles, customer-managed policies, and AWS-managed policies.
 
-The `scan` command requires that file.
+* You must have AWS credentials configured that can be used by the CLI.
 
-## Quick start
+* You must have the privileges to run [iam:GetAccountAuthorizationDetails](https://docs.aws.amazon.com/IAM/latest/APIReference/API_GetAccountAuthorizationDetails.html). The `arn:aws:iam::aws:policy/SecurityAudit` policy includes this, as do many others that allow Read access to the IAM Service.
 
-* Set your AWS access keys as environment variables:
-
-```bash
-export AWS_ACCESS_KEY_ID=...
-export AWS_SECRET_ACCESS_KEY=...
-# If you are using MFA or STS; optional but highly recommended
-export AWS_SESSION_TOKEN=...
-```
-
-* Download the account authorization details
+* To download the account authorization details, ensure you are authenticated to AWS, then run `cloudsplaining`'s `download` command:
 
 ```bash
 cloudsplaining download
 ```
 
+* If you prefer to use your `~/.aws/credentials` file instead of environment variables, you can specify the profile name:
+
+```bash
+cloudsplaining download --profile myprofile
+```
+
+It will download a JSON file in your current directory that contains your account authorization detail information.
+
 ## Additional Details
-
-#### Order of Precedence
-
-* **Environment variables**: The `download` command will first look for the existence of your AWS access keys in environment variables (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_SESSION_TOKEN`).
-  - Note: If you do not have AWS_SESSION_TOKEN set and are using static access keys, I highly recommend the use of [aws-mfa](https://github.com/broamski/aws-mfa) for security reasons.
-
-* **Shared Credentials file**:
-  - If those environment variables are not set, it will then use the `default` profile in your `~/.aws/credentials` file, if a different profile name is not provided via the argument `--profile`.
-  - If you specify `--profile all`, it will run the download command recursively for every profile in your `~/.aws/credentials` file.
-
 
 ### Required AWS IAM Policy
 

--- a/docs/user-guide/scan-account.md
+++ b/docs/user-guide/scan-account.md
@@ -1,14 +1,40 @@
-# Scanning an Account
+#### Scanning the Authorization Details file
 
-Scan the Account Authorization details file with the following command
+Now that we've downloaded the account authorization file, we can scan *all* of the AWS IAM policies with `cloudsplaining`.
 
+Run the following command:
+
+```bash
+cloudsplaining scan --exclusions-file exclusions.yml --input examples/files/example.json --output examples/files/
 ```
-cloudsplaining scan --input default.json --exclusions-file my-exclusions.yml
+
+It will create an HTML report like [this](https://opensource.salesforce.com/cloudsplaining/):
+
+> ![](docs/_images/cloudsplaining-report.gif)
+
+
+It will also create a raw JSON data file:
+
+* `default-iam-results.json`: This contains the raw JSON output of the report. You can use this data file for operating on the scan results for various purposes. For example, you could write a Python script that parses this data and opens up automated JIRA issues or Salesforce Work Items. An example entry is shown below. The full example can be viewed at [examples/output/example-authz-details-results.json](examples/files/iam-results-example.json)
+
+```json
+{
+    "example-authz-details": [
+        {
+            "AccountID": "012345678901",
+            "ManagedBy": "Customer",
+            "PolicyName": "InsecureUserPolicy",
+            "Arn": "arn:aws:iam::012345678901:user/userwithlotsofpermissions",
+            "ActionsCount": 2,
+            "ServicesCount": 1,
+            "Actions": [
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+            ],
+            "Services": [
+                "s3"
+            ]
+        }
+    ]
+}
 ```
-
-* It will generate three files:
-  1. The single-file HTML report
-  2. The triage CSV worksheet, and
-  3. The raw JSON data file
-
-

--- a/docs/user-guide/troubleshooting.md
+++ b/docs/user-guide/troubleshooting.md
@@ -1,14 +1,13 @@
 # Troubleshooting
 
-### Running the command (Path issues)
-
-* *I followed the installation instructions but can't execute the program via command line. What do I do?*
+**I followed the installation instructions but can't execute the program via command line at all. What do I do?**
 
 This is likely an issue with your PATH. Your PATH environment variable is not considering the binary packages installed by `pip3`. On a Mac, you can likely fix this by entering the command below, depending on the versions you have installed. YMMV.
 
 ```bash
-# Python 3.7
 export PATH=$HOME/Library/Python/3.7/bin/:$PATH
-# Python 3.8
-export PATH=$HOME/Library/Python/3.8/bin/:$PATH
 ```
+
+**I followed the installation instructions but I am receiving a `ModuleNotFoundError` that says `No module named policy_sentry.analysis.expand`. What should I do?**
+
+Try upgrading to the latest version of Cloudsplaining. This error was fixed in version 0.0.10.

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['test*', 'tmp*']),
     tests_require=TESTS_REQUIRE,
     install_requires=[
-        'policy_sentry',
+        'policy_sentry>=0.8.0.3',
         'click',
         'click_log',
         'schema',


### PR DESCRIPTION
* Removed the recursive credentials method from the `download` command.
* Fixed occasional installation error occurring from outdated Policy Sentry versions.
* Fixed instructions for the `download` command.