### PR TITLE
Fixes #23 - issue arising from policies with "Deny" with no resource constraints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.0.11 (2020-05-06)
+* Fixed an issue arising from policies where "Deny" was used in effect with no resource constraints. Fixes #23.
+
 ## 0.0.10 (2020-05-05)
 * Removed the recursive credentials method from the `download` command.
 * Fixed occasional installation error occurring from outdated Policy Sentry versions.

--- a/cloudsplaining/bin/cloudsplaining
+++ b/cloudsplaining/bin/cloudsplaining
@@ -7,7 +7,7 @@
 """
     Cloudsplaining is an AWS IAM Assessment tool that identifies violations of least privilege and generates a risk-prioritized HTML report with a triage worksheet.
 """
-__version__ = "0.0.10"
+__version__ = "0.0.11"
 import click
 from cloudsplaining import command
 

--- a/cloudsplaining/scan/policy_document.py
+++ b/cloudsplaining/scan/policy_document.py
@@ -40,7 +40,8 @@ class PolicyDocument:
         """Output all allowed IAM Actions, regardless of resource constraints"""
         allowed_actions = []
         for statement in self.statements:
-            allowed_actions.extend(statement.expanded_actions)
+            if statement.expanded_actions:
+                allowed_actions.extend(statement.expanded_actions)
         allowed_actions = list(dict.fromkeys(allowed_actions))
         return allowed_actions
 
@@ -50,7 +51,8 @@ class PolicyDocument:
         allowed_actions = []
         for statement in self.statements:
             if not statement.has_resource_constraints:
-                allowed_actions.extend(statement.expanded_actions)
+                if statement.expanded_actions:
+                    allowed_actions.extend(statement.expanded_actions)
         allowed_actions = list(dict.fromkeys(allowed_actions))
         return allowed_actions
 

--- a/cloudsplaining/scan/statement_detail.py
+++ b/cloudsplaining/scan/statement_detail.py
@@ -81,7 +81,7 @@ class StatementDetail:
         """If NotAction is used, calculate the allowed actions - i.e., what it would be """
         effective_actions = []
         if not self.not_action:
-            return False
+            return None
         not_actions_expanded = determine_actions_to_expand(self.not_action)
         not_actions_expanded_lowercase = [x.lower() for x in not_actions_expanded]
 
@@ -116,12 +116,12 @@ class StatementDetail:
             return effective_actions
         elif self.has_resource_constraints and self.effect_deny:
             logger.debug("NOTE: Haven't decided if we support Effect Deny here?")
-            return False
+            return None
         elif not self.has_resource_constraints and self.effect_deny:
             logger.debug("NOTE: Haven't decided if we support Effect Deny here?")
-            return False
+            return None
         else:
-            return False
+            return None
 
     @property
     def has_not_resource_with_allow(self):


### PR DESCRIPTION
Also bumps to version 0.0.11.

I'm going to wait until I merge the updated version of Policy Sentry too so the homebrew formula shows a version of Policy Sentry that doesn't have the overly verbose logging issue described in https://github.com/salesforce/policy_sentry/issues/178.