### PR TITLE
Fix inline policy processing for roles after 2ae75edf

### DIFF
--- a/cloudsplaining/scan/role_details.py
+++ b/cloudsplaining/scan/role_details.py
@@ -156,7 +156,7 @@ class RoleDetail:
         for managed_policy in self.attached_managed_policies:
             actions.extend(managed_policy.policy_document.all_allowed_actions)
         for inline_policy in self.inline_policies:
-            actions.extend(self.inline_policies[inline_policy]["PolicyDocument"].all_allowed_actions)
+            actions.extend(inline_policy.policy_document.all_allowed_actions)
         actions = list(dict.fromkeys(actions))
         actions.sort()
         return actions
@@ -168,7 +168,7 @@ class RoleDetail:
         for managed_policy in self.attached_managed_policies:
             statements.extend(managed_policy.policy_document.statements)
         for inline_policy in self.inline_policies:
-            statements.extend(self.inline_policies[inline_policy]["PolicyDocument"].statements)
+            statements.extend(inline_policy.policy_document.statements)
         return statements
 
     @property


### PR DESCRIPTION
In 2ae75edf the format for inline policies was changed but subsequent
checks for roles stil rely on the dictionary format. This fix updates the
processing code to expect the new format (in line with what managed
policies already have and what was done for the other principal types)

## What does this PR do?

Fix a bug as described above

## What gif best describes this PR or how it makes you feel?

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)

## Completion checklist

- [ ] Additions and changes have unit tests
- [ ] [Python Unit tests, Pylint, security testing, and Integration tests are passing.](https://github.com/salesforce/policy_sentry/actions). GitHub actions checks this automatically.
  - [ ] `invoke test.format`
  - [ ] `invoke test.lint`
  - [ ] `invoke unit.pytest`
  - [ ] `invoke test.security`
- [ ] Javascript tests are passing (`npm test`)
- [ ] If the UI has been modified, generate a new example report
  - [ ] `npm build` - to build the Javascript bundle
  - [ ] `python3 ./utils/generate_example_report.py` - to generate the new example report
- [ ] The pull request has been appropriately labeled using the provided PR labels
