### PR TITLE
[WIP] Statement scanning performance improvements

### DIFF
--- a/cloudsplaining/scan/statement_detail.py
+++ b/cloudsplaining/scan/statement_detail.py
@@ -1,5 +1,8 @@
 """Abstracts evaluation of IAM Policy statements."""
 import logging
+
+from cached_property import cached_property
+
 from policy_sentry.analysis.analyze import determine_actions_to_expand
 from policy_sentry.querying.actions import (
     remove_actions_not_matching_access_level,
@@ -140,9 +143,10 @@ class StatementDetail:
                 )
         return result
 
-    @property
+    @cached_property
     def expanded_actions(self):
         """Expands the full list of allowed actions from the Policy/"""
+        
         if self.actions:
             expanded = determine_actions_to_expand(self.actions)
             expanded.sort()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 beautifulsoup4==4.9.3
 boto3==1.16.43
 botocore==1.19.43
+cached-property==1.5.2
 certifi==2020.12.5
 chardet==4.0.0
 click==7.1.2


### PR DESCRIPTION
## What does this PR do?

[//]: # (Required: Describe the effects of your pull request in detail. If
multiple changes are involved, a bulleted list is often useful.)

Improves policy & statement evaluation performance by:
- removing redundant calls
- simplifying conditionals and exiting early wherever possible
- adding `cache-property` package so that expensive class attr calls are cached after the first call

Basic testing using `time` and a sample script (pasted below) yielded these results for a policy with a single wildcard statement:
```
    "Statement": [
        {
            "Effect": "Allow",
            "Action": [
                "s3:*"
            ],
            "Resource": "*"
        }
    ]
```

**Before**
```
$ python3 profile_script.py  
1.32s user 0.07s system 99% cpu 1.400s total
```

**After**
```
$ python3 profile_script.py  
0.42s user 0.08s system 92% cpu 0.532 total
```

---
Sample script used to profile:
```
# profile_script.py

def scan_policy(policy_json, exclusions_config=DEFAULT_EXCLUSIONS_CONFIG):
    policy_document = PolicyDocument(policy_json)
    exclusions = Exclusions(DEFAULT_EXCLUSIONS_CONFIG)
    policy_finding = PolicyFinding(policy_document, exclusions)
    return policy_finding.results

if __name__ == '__main__':
    test_filepath = "" # replace with path to a policy file
    with open(test_filepath) as f:
        contents = f.read()
    account_authorization_details_cfg = json.loads(contents)
    rendered_html_report = scan_policy(account_authorization_details_cfg)
```

## What gif best describes this PR or how it makes you feel?

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)

Still thinking of one :) 

## Completion checklist

- [ ] Additions and changes have unit tests
- [ ] Python Unit tests, Pylint, security testing, and Integration tests are passing.
- [x] Javascript tests are passing (`npm test`)
- [x] If the UI contents or JavaScript files have been modified, generate a new example report (`npm build` and `python3 ./utils/generate_example_report.py`)
- [ ] The pull request has been appropriately labeled using the provided PR labels
