### PR TITLE
consider iam policy statement condition as a restricted action

### DIFF
--- a/cloudsplaining/scan/policy_document.py
+++ b/cloudsplaining/scan/policy_document.py
@@ -64,7 +64,7 @@ class PolicyDocument:
         """Output all IAM actions that do not practice resource constraints"""
         allowed_actions = []
         for statement in self.statements:
-            if not statement.has_resource_constraints:
+            if not statement.has_resource_constraints and not statement.has_condition:
                 if statement.expanded_actions:
                     allowed_actions.extend(statement.expanded_actions)
         allowed_actions = list(dict.fromkeys(allowed_actions))

--- a/cloudsplaining/scan/statement_detail.py
+++ b/cloudsplaining/scan/statement_detail.py
@@ -36,6 +36,7 @@ class StatementDetail:
         self.json = statement
         self.statement = statement
         self.effect = statement["Effect"]
+        self.condition = statement.get("Condition",None)
         self.resources = self._resources()
         self.actions = self._actions()
         self.not_action = self._not_action()
@@ -44,6 +45,7 @@ class StatementDetail:
 
         self.not_action_effective_actions = self._not_action_effective_actions()
         self.not_resource = self._not_resource()
+        self.has_condition = self._has_condition()
 
     def _actions(self):
         """Holds the actions in a statement"""
@@ -270,6 +272,11 @@ class StatementDetail:
         )
         modify_actions_missing_constraints.sort()
         return modify_actions_missing_constraints
+
+    def _has_condition(self):
+        if self.condition:
+            return True
+        return False
 
 
 def _has_resource_constraints(resources):

--- a/test/scanning/test_policy_document.py
+++ b/test/scanning/test_policy_document.py
@@ -302,3 +302,26 @@ class TestPolicyDocument(unittest.TestCase):
         # Should still include one result
         print(policy_document_2.infrastructure_modification)
         self.assertEqual(policy_document_2.infrastructure_modification, ["autoscaling:UpdateAutoScalingGroup"])
+
+    def test_condition_is_a_restricted_action(self):
+        test_policy = {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "cloudwatch:PutMetricData",
+                "Resource": "*",
+                "Condition": {"StringEquals": {"cloudwatch:namespace": "Namespace"}}
+            }]
+        }
+        policy_document = PolicyDocument(test_policy)
+        self.assertListEqual(policy_document.all_allowed_unrestricted_actions, [])
+        test_policy_without_condition = {
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Action": "cloudwatch:PutMetricData",
+                "Resource": "*",
+            }]
+        }
+        policy_document_without_condition = PolicyDocument(test_policy_without_condition)
+        self.assertListEqual(policy_document_without_condition.all_allowed_unrestricted_actions, ["cloudwatch:PutMetricData"])


### PR DESCRIPTION
## What does this PR do?
If an IAM policy contains a condition, consider the action as "restricted action" in cloudsplaining. 
Related issue: https://github.com/bridgecrewio/checkov/issues/990

## What gif best describes this PR or how it makes you feel?
![](https://media0.giphy.com/media/fwbZnTftCXVocKzfxR/giphy.gif?cid=ecf05e47d8535i6x3deem55rxraq62grqchmshbrm0argu3l&rid=giphy.gif)


## Completion checklist

- [x] Additions and changes have unit tests
- [x] Python Unit tests, Pylint, security testing, and Integration tests are passing.
- [x] Javascript tests are passing (`npm test`)
- [x] If the UI contents or JavaScript files have been modified, generate a new example report (`npm build` and `python3 ./utils/generate_example_report.py`)
- [ ] The pull request has been appropriately labeled using the provided PR labels
