### PR TITLE
Avoid Flagging If Deny On Scan Actions Without Constraints

### DIFF
--- a/cloudsplaining/scan/policy_document.py
+++ b/cloudsplaining/scan/policy_document.py
@@ -137,7 +137,7 @@ class PolicyDocument:
         do not have resource constraints"""
         result = []
         for statement in self.statements:
-            if statement.permissions_management_actions_without_constraints:
+            if statement.effect == "Allow" and statement.permissions_management_actions_without_constraints:
                 result.extend(
                     statement.permissions_management_actions_without_constraints
                 )
@@ -149,7 +149,7 @@ class PolicyDocument:
         do not have resource constraints"""
         result = []
         for statement in self.statements:
-            if statement.write_actions_without_constraints:
+            if statement.effect == "Allow" and statement.write_actions_without_constraints:
                 result.extend(statement.write_actions_without_constraints)
         return result
 
@@ -159,7 +159,7 @@ class PolicyDocument:
         do not have resource constraints"""
         result = []
         for statement in self.statements:
-            if statement.tagging_actions_without_constraints:
+            if statement.effect == "Allow" and statement.tagging_actions_without_constraints:
                 result.extend(statement.tagging_actions_without_constraints)
         return result
 

--- a/test/scanning/test_policy_document.py
+++ b/test/scanning/test_policy_document.py
@@ -362,3 +362,32 @@ class TestPolicyDocument(unittest.TestCase):
         }
         policy_document_without_condition = PolicyDocument(test_policy_without_condition)
         self.assertListEqual(policy_document_without_condition.all_allowed_unrestricted_actions, ["cloudwatch:PutMetricData"])
+
+    def test_actions_without_constraints_deny(self):
+        test_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Deny",
+                    "Action": [
+                        "iam:UpdateUser",
+                        "iam:TagRole",
+                        "iam:UntagRole",
+                        "s3:PutBucketAcl",
+                        "s3:GetObject",
+                        "s3:PutObject",
+                        "s3:CreateBucket"
+                    ],
+                    "Resource": "*"
+                }
+            ]
+        }
+        policy_document = PolicyDocument(test_policy)
+        results = policy_document.permissions_management_without_constraints
+        self.assertListEqual(results, [])
+
+        results = policy_document.write_actions_without_constraints
+        self.assertListEqual(results, [])
+
+        results = policy_document.tagging_actions_without_constraints
+        self.assertListEqual(results, [])

--- a/test/scanning/test_statement_detail.py
+++ b/test/scanning/test_statement_detail.py
@@ -273,3 +273,28 @@ class TestStatementDetail(unittest.TestCase):
         statement = StatementDetail(this_statement)
         results = statement.has_resource_constraints
         self.assertFalse(results)
+
+    def test_actions_without_constraints(self):
+        this_statement = {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": [
+                "iam:UpdateUser",
+                "iam:TagRole",
+                "iam:UntagRole",
+                "s3:PutBucketAcl",
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:CreateBucket"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+        statement = StatementDetail(this_statement)
+        results = statement.permissions_management_actions_without_constraints
+        self.assertListEqual(results, ["iam:UpdateUser", "s3:PutBucketAcl"])
+        results = statement.write_actions_without_constraints
+        self.assertListEqual(results, ["s3:CreateBucket", "s3:PutObject"])
+        results = statement.tagging_actions_without_constraints
+        self.assertListEqual(results, ["iam:TagRole", "iam:UntagRole"])


### PR DESCRIPTION
Hello,

Thank you for an excellent tool :)

## What does this PR do?

This PR is having a go at avoiding the flagging of issues on the _actions without constraints_ group of scans when a Deny effect is used.

I believe there is precedent for this because other checks already include the filtering out where deny is involved.

I work on the Checkov scanning tool and I am now working on the Cloudsplaining integration somewhat and the following issue ultimately bought me here so you can get some extra context there!

https://github.com/bridgecrewio/checkov/issues/1037

If you are alright with the logic of this but would like another implementation then please let me know what is the best way to go. If you don't like this, please let me if there is another way I can achieve this for Checkov by adding something else to the codebase like a wrapper with this functionality or whatever!


## What gif best describes this PR or how it makes you feel?
![Count Me In](https://media.giphy.com/media/z964EmS0VNVdUv9jyW/giphy.gif)


## Completion checklist

- [x] Additions and changes have unit tests
- [x] Python Unit tests, Pylint, security testing, and Integration tests are passing.
- [x] Javascript tests are passing (`npm test`)
- [x] If the UI contents or JavaScript files have been modified, generate a new example report (`npm build` and `python3 ./utils/generate_example_report.py`) - n/a.
- [x] The pull request has been appropriately labeled using the provided PR labels - CLA signed. Don't know what other labels to use!
