### PR TITLE
Add quotes around example account numbers

### DIFF
--- a/cloudsplaining/shared/multi-account-config.yml
+++ b/cloudsplaining/shared/multi-account-config.yml
@@ -1,4 +1,4 @@
 accounts:
-  default_account: 123456789012
-  prod: 123456789013
-  test: 123456789014
+  default_account: "123456789012"
+  prod: "123456789013"
+  test: "123456789014"


### PR DESCRIPTION
## What does this PR do?

The account numbers in the example don't require quotes but if a user
were to fill in account numbers with leading zeroes then YAML won't
interpret those as octal (for YAML 1.1) or base 10 integer (YAML 1.2).
This simple change makes it less likely to run into this issue when
using this template as a starter.

## What gif best describes this PR or how it makes you feel?

This is a really simple change. I haven't tested it. I hope this comic does not apply. 😛 

![4035e9c311e1e0603d8bc709239ba06f](https://user-images.githubusercontent.com/18475564/114478935-8cdaff80-9c3e-11eb-9dda-80d46c0ffa85.jpeg)


## Completion checklist

- [ ] Additions and changes have unit tests
- [ ] Python Unit tests, Pylint, security testing, and Integration tests are passing.
- [ ] Javascript tests are passing (`npm test`)
- [ ] If the UI contents or JavaScript files have been modified, generate a new example report (`npm build` and `python3 ./utils/generate_example_report.py`)
- [ ] The pull request has been appropriately labeled using the provided PR labels
