### PR TITLE
Add type hints to PolicyDocument and StatementDetail

### DIFF
--- a/cloudsplaining/bin/version.py
+++ b/cloudsplaining/bin/version.py
@@ -1,2 +1,2 @@
 # pylint: disable=missing-module-docstring
-__version__ = '0.4.2'
+__version__ = "0.4.2"

--- a/cloudsplaining/scan/inline_policy.py
+++ b/cloudsplaining/scan/inline_policy.py
@@ -1,5 +1,7 @@
 """Represents the Inline Policies (UserPolicyList, GroupPolicyList, RolePolicyList) entries under each principal."""
 import json
+from typing import Dict, Any, cast
+
 from cloudsplaining.shared.utils import get_non_provider_id
 from cloudsplaining.scan.policy_document import PolicyDocument
 from cloudsplaining.shared.exclusions import DEFAULT_EXCLUSIONS, Exclusions
@@ -10,7 +12,9 @@ class InlinePolicy:
     Contains information about an Inline Policy, including the Policy Document
     """
 
-    def __init__(self, policy_detail, exclusions=DEFAULT_EXCLUSIONS):
+    def __init__(
+        self, policy_detail: Dict[str, Any], exclusions: Exclusions = DEFAULT_EXCLUSIONS
+    ) -> None:
         """
         Initialize the InlinePolicy object.
 
@@ -21,9 +25,9 @@ class InlinePolicy:
                 "The exclusions provided is not an Exclusions type object. "
                 "Please supply an Exclusions object and try again."
             )
-        self.policy_name = policy_detail.get("PolicyName")
+        self.policy_name = policy_detail.get("PolicyName", "")
         self.policy_document = PolicyDocument(
-            policy_detail.get("PolicyDocument"), exclusions
+            cast(Dict[str, Any], policy_detail.get("PolicyDocument")), exclusions
         )
         # Generating the provider ID based on a string representation of the Policy Document,
         # to avoid collisions where there are inline policies with the same name but different contents
@@ -33,7 +37,7 @@ class InlinePolicy:
         self.exclusions = exclusions
         self.is_excluded = self._is_excluded(exclusions)
 
-    def _is_excluded(self, exclusions):
+    def _is_excluded(self, exclusions: Exclusions) -> bool:
         """Determine whether the policy name or policy ID is excluded"""
         return bool(
             exclusions.is_policy_excluded(self.policy_name)
@@ -41,7 +45,7 @@ class InlinePolicy:
         )
 
     @property
-    def json(self):
+    def json(self) -> Dict[str, Any]:
         """Return JSON output for high risk actions"""
         result = dict(
             PolicyName=self.policy_name,
@@ -57,7 +61,7 @@ class InlinePolicy:
         return result
 
     @property
-    def json_large(self):
+    def json_large(self) -> Dict[str, Any]:
         """Return JSON output - including Infra Modification actions, which can be large"""
         result = dict(
             PolicyName=self.policy_name,

--- a/cloudsplaining/scan/policy_document.py
+++ b/cloudsplaining/scan/policy_document.py
@@ -27,7 +27,9 @@ class PolicyDocument:
     Holds the actual AWS IAM Policy document
     """
 
-    def __init__(self, policy: Dict[str, Any], exclusions: Exclusions = DEFAULT_EXCLUSIONS) -> None:
+    def __init__(
+        self, policy: Dict[str, Any], exclusions: Exclusions = DEFAULT_EXCLUSIONS
+    ) -> None:
         statement_structure = policy.get("Statement", [])
         self.policy = policy
         self.statements = []
@@ -56,7 +58,9 @@ class PolicyDocument:
         """Output all allowed IAM Actions, regardless of resource constraints"""
         allowed_actions = set()
         for statement in self.statements:
-            if statement.effect_allow:  # if Effect is "Deny" - it is not an allowed action
+            if (
+                statement.effect_allow
+            ):  # if Effect is "Deny" - it is not an allowed action
                 if statement.expanded_actions:
                     allowed_actions.update(statement.expanded_actions)
         allowed_actions = self.filter_deny_statements(allowed_actions)
@@ -64,12 +68,14 @@ class PolicyDocument:
 
     def filter_deny_statements(self, allowed_actions: Set[str]) -> Set[str]:
         """
-            filter all denied statements from actions
+        filter all denied statements from actions
         """
         for statement in self.statements:
             if statement.effect_deny:
                 if statement.expanded_actions:
-                    allowed_actions = allowed_actions.difference(statement.expanded_actions)
+                    allowed_actions = allowed_actions.difference(
+                        statement.expanded_actions
+                    )
         return allowed_actions
 
     @property
@@ -77,7 +83,11 @@ class PolicyDocument:
         """Output all IAM actions that do not practice resource constraints"""
         allowed_actions = set()
         for statement in self.statements:
-            if not statement.has_resource_constraints and not statement.has_condition and statement.effect_allow:
+            if (
+                not statement.has_resource_constraints
+                and not statement.has_condition
+                and statement.effect_allow
+            ):
                 if statement.expanded_actions:
                     allowed_actions.update(statement.expanded_actions)
         allowed_actions = self.filter_deny_statements(allowed_actions)
@@ -136,7 +146,10 @@ class PolicyDocument:
         do not have resource constraints"""
         result = []
         for statement in self.statements:
-            if statement.effect == "Allow" and statement.permissions_management_actions_without_constraints:
+            if (
+                statement.effect == "Allow"
+                and statement.permissions_management_actions_without_constraints
+            ):
                 result.extend(
                     statement.permissions_management_actions_without_constraints
                 )
@@ -148,7 +161,10 @@ class PolicyDocument:
         do not have resource constraints"""
         result = []
         for statement in self.statements:
-            if statement.effect == "Allow" and statement.write_actions_without_constraints:
+            if (
+                statement.effect == "Allow"
+                and statement.write_actions_without_constraints
+            ):
                 result.extend(statement.write_actions_without_constraints)
         return result
 
@@ -158,11 +174,16 @@ class PolicyDocument:
         do not have resource constraints"""
         result = []
         for statement in self.statements:
-            if statement.effect == "Allow" and statement.tagging_actions_without_constraints:
+            if (
+                statement.effect == "Allow"
+                and statement.tagging_actions_without_constraints
+            ):
                 result.extend(statement.tagging_actions_without_constraints)
         return result
 
-    def allows_specific_actions_without_constraints(self, specific_actions: List[str]) -> List[str]:
+    def allows_specific_actions_without_constraints(
+        self, specific_actions: List[str]
+    ) -> List[str]:
         """Determine whether or not a list of specific IAM Actions are allowed without resource constraints."""
         allowed = []
         if not isinstance(specific_actions, list):

--- a/cloudsplaining/scan/statement_detail.py
+++ b/cloudsplaining/scan/statement_detail.py
@@ -37,7 +37,7 @@ class StatementDetail:
         self.json = statement
         self.statement = statement
         self.effect = statement["Effect"]
-        self.condition = statement.get("Condition",None)
+        self.condition = statement.get("Condition", None)
         self.resources = self._resources()
         self.actions = self._actions()
         self.not_action = self._not_action()
@@ -217,7 +217,9 @@ class StatementDetail:
             )
         return result
 
-    def missing_resource_constraints(self, exclusions: Exclusions = DEFAULT_EXCLUSIONS) -> List[str]:
+    def missing_resource_constraints(
+        self, exclusions: Exclusions = DEFAULT_EXCLUSIONS
+    ) -> List[str]:
         """Return a list of any actions - regardless of access level - allowed by the statement that do not leverage
         resource constraints."""
         if not isinstance(exclusions, Exclusions):
@@ -262,7 +264,9 @@ class StatementDetail:
                 always_actions_found.append(action)
 
         modify_actions_missing_constraints = set()
-        modify_actions_missing_constraints.update(remove_read_level_actions(actions_missing_resource_constraints))
+        modify_actions_missing_constraints.update(
+            remove_read_level_actions(actions_missing_resource_constraints)
+        )
         modify_actions_missing_constraints.update(always_actions_found)
 
         return list(modify_actions_missing_constraints)

--- a/cloudsplaining/scan/statement_detail.py
+++ b/cloudsplaining/scan/statement_detail.py
@@ -1,5 +1,6 @@
 """Abstracts evaluation of IAM Policy statements."""
 import logging
+from typing import Dict, Any, List, Optional
 
 from cached_property import cached_property
 
@@ -32,7 +33,7 @@ class StatementDetail:
     Analyzes individual statements within a policy
     """
 
-    def __init__(self, statement):
+    def __init__(self, statement: Dict[str, Any]) -> None:
         self.json = statement
         self.statement = statement
         self.effect = statement["Effect"]
@@ -41,53 +42,53 @@ class StatementDetail:
         self.actions = self._actions()
         self.not_action = self._not_action()
 
-        self.has_resource_constraints = _has_resource_constraints(self.resources)
+        self.has_resource_constraints = self._has_resource_constraints()
 
         self.not_action_effective_actions = self._not_action_effective_actions()
         self.not_resource = self._not_resource()
         self.has_condition = self._has_condition()
 
-    def _actions(self):
+    def _actions(self) -> List[str]:
         """Holds the actions in a statement"""
         actions = self.statement.get("Action")
         if not actions:
             return []
         if not isinstance(actions, list):
-            actions = [actions]
+            return [actions]
         return actions
 
-    def _resources(self):
+    def _resources(self) -> List[str]:
         """Holds the resource ARNs in a statement"""
         resources = self.statement.get("Resource")
         if not resources:
             return []
         # If it's a string, turn it into a list
         if not isinstance(resources, list):
-            resources = [resources]
+            return [resources]
         return resources
 
-    def _not_action(self):
+    def _not_action(self) -> List[str]:
         """Holds the NotAction details.
         We won't do anything with it - but we will flag it as something for the assessor to triage."""
         not_action = self.statement.get("NotAction")
         if not not_action:
             return []
         if not isinstance(not_action, list):
-            not_action = [not_action]
+            return [not_action]
         return not_action
 
-    def _not_resource(self):
+    def _not_resource(self) -> List[str]:
         """Holds the NotResource details.
         We won't do anything with it - but we will flag it as something for the assessor to triage."""
         not_resource = self.statement.get("NotResource")
         if not not_resource:
             return []
         if not isinstance(not_resource, list):
-            not_resource = [not_resource]
+            return [not_resource]
         return not_resource
 
     # @property
-    def _not_action_effective_actions(self):
+    def _not_action_effective_actions(self) -> Optional[List[str]]:
         """If NotAction is used, calculate the allowed actions - i.e., what it would be """
         effective_actions = []
         if not self.not_action:
@@ -137,7 +138,7 @@ class StatementDetail:
         return None  # pragma: no cover
 
     @property
-    def has_not_resource_with_allow(self):
+    def has_not_resource_with_allow(self) -> bool:
         """Per the AWS documentation, the NotResource should NEVER be used with the Allow Effect.
         See documentation here. https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_notresource.html#notresource-element-combinations"""
         if self.not_resource and self.effect_allow:
@@ -149,7 +150,7 @@ class StatementDetail:
         return False
 
     @cached_property
-    def expanded_actions(self):
+    def expanded_actions(self) -> Optional[List[str]]:
         """Expands the full list of allowed actions from the Policy/"""
 
         if self.actions:
@@ -164,17 +165,17 @@ class StatementDetail:
             )
 
     @property
-    def effect_deny(self):
+    def effect_deny(self) -> bool:
         """Check if the Effect of the Policy is 'Deny'"""
         return bool(self.effect == "Deny")
 
     @property
-    def effect_allow(self):
+    def effect_allow(self) -> bool:
         """Check if the Effect of the Policy is 'Allow'"""
         return bool(self.effect == "Allow")
 
     @property
-    def services_in_use(self):
+    def services_in_use(self) -> List[str]:
         """Get a list of the services in use by the statement."""
         service_prefixes = set()
         for action in self.expanded_actions:
@@ -183,7 +184,7 @@ class StatementDetail:
         return sorted(service_prefixes)
 
     @property
-    def permissions_management_actions_without_constraints(self):
+    def permissions_management_actions_without_constraints(self) -> List[str]:
         """Where applicable, returns a list of 'Permissions management' IAM actions in the statement that
         do not have resource constraints"""
         result = []
@@ -195,7 +196,7 @@ class StatementDetail:
         return result
 
     @property
-    def write_actions_without_constraints(self):
+    def write_actions_without_constraints(self) -> List[str]:
         """Where applicable, returns a list of 'Write' level IAM actions in the statement that
         do not have resource constraints"""
         result = []
@@ -206,7 +207,7 @@ class StatementDetail:
         return result
 
     @property
-    def tagging_actions_without_constraints(self):
+    def tagging_actions_without_constraints(self) -> List[str]:
         """Where applicable, returns a list of 'Tagging' level IAM actions in the statement that
         do not have resource constraints"""
         result = []
@@ -216,7 +217,7 @@ class StatementDetail:
             )
         return result
 
-    def missing_resource_constraints(self, exclusions=DEFAULT_EXCLUSIONS):
+    def missing_resource_constraints(self, exclusions: Exclusions = DEFAULT_EXCLUSIONS) -> List[str]:
         """Return a list of any actions - regardless of access level - allowed by the statement that do not leverage
         resource constraints."""
         if not isinstance(exclusions, Exclusions):
@@ -232,8 +233,8 @@ class StatementDetail:
         return exclusions.get_allowed_actions(actions_missing_resource_constraints)
 
     def missing_resource_constraints_for_modify_actions(
-        self, exclusions=DEFAULT_EXCLUSIONS
-    ):
+        self, exclusions: Exclusions = DEFAULT_EXCLUSIONS
+    ) -> List[str]:
         """
         Determine whether or not any actions at the 'Write', 'Permissions management', or 'Tagging' access levels
         are allowed by the statement without resource constraints.
@@ -260,33 +261,25 @@ class StatementDetail:
             if action.lower() in always_look_for_actions:
                 always_actions_found.append(action)
 
-        modify_actions_missing_constraints = remove_read_level_actions(
-            actions_missing_resource_constraints
-        )
-        modify_actions_missing_constraints = (
-            modify_actions_missing_constraints + always_actions_found
-        )
+        modify_actions_missing_constraints = set()
+        modify_actions_missing_constraints.update(remove_read_level_actions(actions_missing_resource_constraints))
+        modify_actions_missing_constraints.update(always_actions_found)
 
-        modify_actions_missing_constraints = list(
-            dict.fromkeys(modify_actions_missing_constraints)
-        )
-        modify_actions_missing_constraints.sort()
-        return modify_actions_missing_constraints
+        return list(modify_actions_missing_constraints)
 
-    def _has_condition(self):
+    def _has_condition(self) -> bool:
         if self.condition:
             return True
         return False
 
-
-def _has_resource_constraints(resources):
-    """Determine whether or not the statement allows resource constraints."""
-    if len(resources) == 0:
-        # This is probably a NotResources situation which we do not support.
-        pass
-    if len(resources) == 1 and resources[0] == "*":
-        return False
-    elif len(resources) > 1:  # pragma: no cover
-        # It's possible that someone writes a bad policy that includes both a resource ARN as well as a wildcard.
-        return not any(resource == "*" for resource in resources)
-    return True
+    def _has_resource_constraints(self) -> bool:
+        """Determine whether or not the statement allows resource constraints."""
+        if len(self.resources) == 0:
+            # This is probably a NotResources situation which we do not support.
+            pass
+        if len(self.resources) == 1 and self.resources[0] == "*":
+            return False
+        elif len(self.resources) > 1:  # pragma: no cover
+            # It's possible that someone writes a bad policy that includes both a resource ARN as well as a wildcard.
+            return not any(resource == "*" for resource in self.resources)
+        return True

--- a/cloudsplaining/shared/exclusions.py
+++ b/cloudsplaining/shared/exclusions.py
@@ -5,7 +5,7 @@
 # For full license text, see the LICENSE file in the repo root
 # or https://opensource.org/licenses/BSD-3-Clause
 import logging
-from typing import List
+from typing import List, Union
 
 from cloudsplaining.shared.validation import check_exclusions_schema
 from cloudsplaining.shared.constants import DEFAULT_EXCLUSIONS_CONFIG
@@ -107,7 +107,7 @@ class Exclusions:
         else:
             return False  # pragma: no cover
 
-    def is_policy_excluded(self, policy_name):
+    def is_policy_excluded(self, policy_name: str) -> bool:
         """
         Supply a policy name or path, and get a decision about whether or not it is excluded.
 
@@ -155,13 +155,13 @@ class Exclusions:
 
 
 # pylint: disable=inconsistent-return-statements
-def is_name_excluded(name, exclusions_list):
+def is_name_excluded(name: str, exclusions_list: Union[str, List[str]]) -> bool:
     """
     :param name: The name of the policy, role, user, or group
     :param exclusions_list: List of exclusions
     :return:
     """
-    result = None
+    result = False
     if isinstance(exclusions_list, str):
         exclusions_list = [exclusions_list]
 

--- a/cloudsplaining/shared/exclusions.py
+++ b/cloudsplaining/shared/exclusions.py
@@ -5,6 +5,8 @@
 # For full license text, see the LICENSE file in the repo root
 # or https://opensource.org/licenses/BSD-3-Clause
 import logging
+from typing import List
+
 from cloudsplaining.shared.validation import check_exclusions_schema
 from cloudsplaining.shared.constants import DEFAULT_EXCLUSIONS_CONFIG
 from cloudsplaining.shared import utils
@@ -133,25 +135,23 @@ class Exclusions:
                 "Please supply User, Group, or Role as the principal argument."
             )
 
-    def get_allowed_actions(self, requested_actions):
+    def get_allowed_actions(self, requested_actions: List[str]) -> List[str]:
         """Given a list of actions, it will evaluate those actions against the exclusions configuration and return a
         list of actions after filtering for exclusions."""
 
-        always_include_actions = []
+        always_include_actions = set()
         # ALWAYS INCLUDE ACTIONS
         for action in requested_actions:
             for include_action in self.include_actions:
                 if action.lower() == include_action.lower():
-                    always_include_actions.append(action)
+                    always_include_actions.add(action)
         # RULE OUT EXCLUDED ACTIONS
-        actions_minus_exclusions = []
+        actions_minus_exclusions = set()
         for action in requested_actions:
             if not is_name_excluded(action.lower(), self.exclude_actions):
-                actions_minus_exclusions.append(action)
+                actions_minus_exclusions.add(action)
 
-        results = always_include_actions + actions_minus_exclusions
-        results = list(dict.fromkeys(results))
-        return results
+        return list(always_include_actions | actions_minus_exclusions)
 
 
 # pylint: disable=inconsistent-return-statements

--- a/cloudsplaining/shared/utils.py
+++ b/cloudsplaining/shared/utils.py
@@ -100,12 +100,12 @@ def get_policy_name(arn):
     return policy_name
 
 
-def capitalize_first_character(some_string):
+def capitalize_first_character(some_string: str) -> str:
     """Description: Capitalizes the first character of a string"""
     return " ".join("".join([w[0].upper(), w[1:].lower()]) for w in some_string.split())
 
 
-def get_non_provider_id(some_string):
+def get_non_provider_id(some_string: str) -> str:
     """
     Not all resources have an ID and some services allow the use of "." in names, which breaks our recursion scheme
     if name is used as an ID. Use SHA256(name) instead.

--- a/cloudsplaining/shared/utils.py
+++ b/cloudsplaining/shared/utils.py
@@ -8,6 +8,8 @@ import os
 import json
 import logging
 from hashlib import sha256
+from typing import List
+
 import yaml
 from policy_sentry.querying.actions import (
     get_action_data,
@@ -22,10 +24,10 @@ GREY = "\33[90m"
 END = "\033[0m"
 
 
-def remove_wildcard_only_actions(actions_list):
+def remove_wildcard_only_actions(actions_list: List[str]) -> List[str]:
     """Given a list of actions, remove the ones that CANNOT be restricted to ARNs, leaving only the ones that CAN."""
     try:
-        actions_list_unique = list(dict.fromkeys(actions_list))
+        actions_list_unique = set(actions_list)
     except TypeError as t_e:  # pragma: no cover
         print(t_e)
         return []
@@ -49,7 +51,7 @@ def remove_wildcard_only_actions(actions_list):
     return results
 
 
-def remove_read_level_actions(actions_list):
+def remove_read_level_actions(actions_list: List[str]) -> List[str]:
     """Given a set of actions, return that list of actions,
     but only with actions at the 'Write', 'Tagging', or 'Permissions management' levels"""
     write_actions = remove_actions_not_matching_access_level(actions_list, "Write")
@@ -61,7 +63,7 @@ def remove_read_level_actions(actions_list):
     return modify_actions
 
 
-def get_full_policy_path(arn):
+def get_full_policy_path(arn: str) -> str:
     """
     Resource string will output strings like the following examples.
 

--- a/test/scanning/test_policy_document.py
+++ b/test/scanning/test_policy_document.py
@@ -59,7 +59,7 @@ class TestPolicyDocument(unittest.TestCase):
         for statement in policy_document.statements:
             actions_missing_resource_constraints.extend(
                 statement.missing_resource_constraints())
-        self.assertEqual(actions_missing_resource_constraints, ['ssm:GetParameters', 'ecr:PutImage'])
+        self.assertCountEqual(actions_missing_resource_constraints, ['ssm:GetParameters', 'ecr:PutImage'])
 
         # Modify only
         # modify_actions_missing_resource_constraints = []
@@ -73,7 +73,7 @@ class TestPolicyDocument(unittest.TestCase):
         for statement in policy_document.statements:
             modify_actions_missing_resource_constraints.extend(
                 statement.missing_resource_constraints_for_modify_actions())
-        self.assertEqual(modify_actions_missing_resource_constraints, ['ecr:PutImage', 'ssm:GetParameters'])
+        self.assertCountEqual(modify_actions_missing_resource_constraints, ['ecr:PutImage', 'ssm:GetParameters'])
 
     def test_policy_document_all_allowed_actions(self):
         """scan.policy_document.all_allowed_actions"""
@@ -106,7 +106,7 @@ class TestPolicyDocument(unittest.TestCase):
             "ssm:GetParameters",
             "iam:CreateAccessKey"
         ]
-        self.assertListEqual(result, expected_result)
+        self.assertCountEqual(result, expected_result)
 
     def test_all_allowed_unrestriced_deny(self):
         """scan.policy_document.all_allowed_unrestricted_actions"""

--- a/test/scanning/test_statement_detail.py
+++ b/test/scanning/test_statement_detail.py
@@ -79,7 +79,7 @@ class TestStatementDetail(unittest.TestCase):
         statement = StatementDetail(this_statement)
         result = statement.missing_resource_constraints()
         # print(result)
-        self.assertListEqual(result, ['secretsmanager:CreateSecret', 'secretsmanager:PutSecretValue'])
+        self.assertCountEqual(result, ['secretsmanager:CreateSecret', 'secretsmanager:PutSecretValue'])
 
     def test_missing_resource_constraints_for_modify_actions(self):
         this_statement = {

--- a/test/scanning/test_statement_detail.py
+++ b/test/scanning/test_statement_detail.py
@@ -100,10 +100,10 @@ class TestStatementDetail(unittest.TestCase):
         result = statement.missing_resource_constraints()
 
         # print(result)
-        self.assertListEqual(result, ['s3:GetObject', 'secretsmanager:PutSecretValue'])
+        self.assertCountEqual(result, ['s3:GetObject', 'secretsmanager:PutSecretValue'])
         result = statement.missing_resource_constraints_for_modify_actions()
         print(result)
-        self.assertListEqual(result, ['s3:GetObject', 'secretsmanager:PutSecretValue'])
+        self.assertCountEqual(result, ['s3:GetObject', 'secretsmanager:PutSecretValue'])
 
     def test_missing_resource_constraints_for_modify_actions_with_override(self):
         import logging
@@ -134,7 +134,7 @@ class TestStatementDetail(unittest.TestCase):
         statement = StatementDetail(this_statement)
         results = statement.missing_resource_constraints_for_modify_actions(DEFAULT_EXCLUSIONS)
         # print(results)
-        self.assertListEqual(results, ['s3:GetObject', 'secretsmanager:PutSecretValue'])
+        self.assertCountEqual(results, ['s3:GetObject', 'secretsmanager:PutSecretValue'])
 
     def test_statement_details_for_action_as_string_instead_of_list(self):
         # Case: when the "Action" is a string

--- a/test/shared/test_exclusions.py
+++ b/test/shared/test_exclusions.py
@@ -24,7 +24,7 @@ class ExclusionsNewTestCase(unittest.TestCase):
             "ec2:DescribeInstances"
         ]
         result = exclusions.get_allowed_actions(test_actions_list)
-        self.assertListEqual(result, ['s3:GetObject', 'ssm:GetParameter', 'ec2:DescribeInstances'])
+        self.assertCountEqual(result, ['s3:GetObject', 'ssm:GetParameter', 'ec2:DescribeInstances'])
 
 
 class ExclusionsTestCase(unittest.TestCase):


### PR DESCRIPTION
## What does this PR do?

- Added type hints to `PolicyDocument` & `StatementDetail`
- Optimized code, where possible. Mostly changed to `set()` instead of `list` usage.

## What gif best describes this PR or how it makes you feel?

![](https://media3.giphy.com/media/3ZNFdTVU4euRy/giphy.gif)

## Completion checklist


- [x] ~~Additions and changes have unit tests~~
- [ ] The pull request has been appropriately labeled using the provided PR labels
- [ ] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [x] ~~If the UI contents or JavaScript files have been modified, generate a new example report:~~

```bash
# Generate the updated Javascript bundle
make build-js

# Generate the example report
make generate-report
```

