### PR TITLE
change behavior of has_resource_constraints and add new unrestrictabl…

### DIFF
--- a/test/scanning/test_statement_detail.py
+++ b/test/scanning/test_statement_detail.py
@@ -271,8 +271,8 @@ class TestStatementDetail(unittest.TestCase):
             ]
         }
         statement = StatementDetail(this_statement)
-        results = statement.has_resource_constraints
-        self.assertFalse(results)
+        results = statement.has_resource_wildcard
+        self.assertTrue(results)
 
     def test_actions_without_constraints(self):
         this_statement = {
@@ -298,3 +298,17 @@ class TestStatementDetail(unittest.TestCase):
         self.assertCountEqual(results, ["s3:CreateBucket", "s3:PutObject"])
         results = statement.tagging_actions_without_constraints
         self.assertCountEqual(results, ["iam:TagRole", "iam:UntagRole"])
+
+    def test_gh_193_has_resource_constraints(self):
+        this_statement = {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken",
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+        statement = StatementDetail(this_statement)
+        self.assertListEqual(statement.unrestrictable_actions, ["ecr:GetAuthorizationToken"])
+        self.assertTrue(statement.has_resource_constraints)


### PR DESCRIPTION
…e_actions attribute

## What does this PR do?

Fixes #195 
I changed the old `_has_resource_constraints` method to `_has_resource_wildcard` and changed the behaviour to actually reflect the intent of the attribute. I also needed to fix couple of other things on how they worked to actually use the hopefully now correct behaviour.

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/HwmDZaI4YEeZ2/source.gif)

## Completion checklist


- [x] Additions and changes have unit tests
- [x] The pull request has been appropriately labeled using the provided PR labels
- [x] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [x] If the UI contents or JavaScript files have been modified, generate a new example report:


