### PR TITLE
Fix NoneType exception thrown when processing a Deny statement using NotActions 

### DIFF
--- a/cloudsplaining/scan/statement_detail.py
+++ b/cloudsplaining/scan/statement_detail.py
@@ -134,11 +134,11 @@ class StatementDetail:
 
         if self.has_resource_wildcard and self.effect_deny:
             logger.debug("NOTE: Haven't decided if we support Effect Deny here?")
-            return None
+            return effective_actions
 
         if not self.has_resource_wildcard and self.effect_deny:
             logger.debug("NOTE: Haven't decided if we support Effect Deny here?")
-            return None
+            return effective_actions
         # only including this so Pylint doesn't yell at us
         return None  # pragma: no cover
 


### PR DESCRIPTION
## What does this PR do?

[//]: # (Required: Describe the effects of your pull request in detail. If
multiple changes are involved, a bulleted list is often useful.)

TL;DR: this change removes a `NoneType` exception being printed.

### Issue

`'NoneType' object is not iterable` exception thrown and printed to console when a statement using `NotActions` with a `Deny` effect is scanned.

The error could lead to people thinking there's an error with the code and the results would be different; which is why I looked into this and found the fix. However, it's a false-positive as results are uneffected by the exception (the statement is skipped which doesn't matter as it's a `Deny` statement).

### Explanation

In the method that creates a full list of effective actions from a statement using a `NotActions` list ([`_not_action_effective_actions`](https://github.com/salesforce/cloudsplaining/blob/b820f02250e7db6ae0454a1efc58be6204e65c3d/cloudsplaining/scan/statement_detail.py#L96)), it skips processing statements with an effect of `Deny` (presumably because there's no need to worry about any denied actions). The way it handles exiting the method with this condition is by returning `None`.

When the [`remove_wildcard_only_actions`](https://github.com/salesforce/cloudsplaining/blob/b820f02250e7db6ae0454a1efc58be6204e65c3d/cloudsplaining/shared/utils.py#L27) function tries to convert the `actions_list` list to a set, it throws an exception because it can't be iterated: `'NoneType' object is not iterable`.

### Change to code's behaviour

This PR replaces the `None` return object with an empty list which fixes the exception. This doesn't modify any behaviour in the functions or policy scans. The try-except block handles the `NoneType` exception and returns an empty list anyway. This change just removes the exception error being printed and the empty list is skipped in the for loop and returned.

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/7vAhjNofTClKQInwCk/giphy-downsized.gif?cid=790b7611ebf25d3b17d18d43e0f7838389d7ba934054cec3&rid=giphy-downsized.gif&ct=g)

## Completion checklist


- [ ] Additions and changes have unit tests
- [ ] The pull request has been appropriately labeled using the provided PR labels
- [ ] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [ ] If the UI contents or JavaScript files have been modified, generate a new example report:

```bash
# Generate the updated Javascript bundle
make build-js

# Generate the example report
make generate-report
```

