### PR TITLE
Fix readthedocs dependencies

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,5 +8,6 @@ mkdocs-material-extensions==1.0.3
 mkdocstrings==0.16.2
 Pygments==2.10.0
 pymdown-extensions==9.1
-pytkdocs==0.14.0
+# mkdocstrings 0.16.2 dpeends on pytkdocs<0.13.0 and >=0.2.0
+pytkdocs<0.13.0
 docutils==0.18.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,12 +1,12 @@
 # unique to ReadTheDocs
 atomicwrites==1.4.0
-distlib==0.3.2
-filelock==3.0.12
-mkdocs==1.2.2
-mkdocs-material==7.2.6
+distlib==0.3.3
+filelock==3.4.0
+mkdocs==1.2.3
+mkdocs-material==8.0.2
 mkdocs-material-extensions==1.0.3
-mkdocstrings==0.15.2
+mkdocstrings==0.16.2
 Pygments==2.10.0
-pymdown-extensions==8.2
-pytkdocs==0.11.1
-docutils==0.17.1
+pymdown-extensions==9.1
+pytkdocs==0.14.0
+docutils==0.18.1


### PR DESCRIPTION
## What does this PR do?

Update Readthedocs dependencies to get rid of annoying dependabot alerts

## Completion checklist

- [x] Additions and changes have unit tests
- [x] The pull request has been appropriately labeled using the provided PR labels
- [x] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [x] If the UI contents or JavaScript files have been modified, generate a new example report:

```bash
# Generate the updated Javascript bundle
make build-js

# Generate the example report
make generate-report
```

