### PR TITLE
AWS_DEFAULT_PROFILE is respected; Path fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ _notes
 results.*
 default.json
 default-iam-report.csv
-private/default-iam-results.json
+private/default-iam-results.json0
 default-results-summary.csv
 iam-new-principal-policy-mapping-example.json
 iam-findings-example.json

--- a/cloudsplaining/command/create_exclusions_file.py
+++ b/cloudsplaining/command/create_exclusions_file.py
@@ -8,7 +8,6 @@ This way, users don't have to remember exactly how to phrase the yaml files, sin
 # For full license text, see the LICENSE file in the repo root
 # or https://opensource.org/licenses/BSD-3-Clause
 import os
-from pathlib import Path
 import logging
 import click
 from cloudsplaining.shared.constants import EXCLUSIONS_TEMPLATE
@@ -22,14 +21,7 @@ logger = logging.getLogger(__name__)
     context_settings=dict(max_content_width=160),
     short_help="Creates a YML file to be used as a custom exclusions template",
 )
-@click.option(
-    "--output-file",
-    "-o",
-    type=click.Path(exists=False),
-    default=os.path.join(os.getcwd(), "exclusions.yml"),
-    required=True,
-    help="Relative path to output file where we want to store the exclusions template.",
-)
+@click.option("-o", "--output-file", type=click.Path(exists=False), default=os.path.join(os.getcwd(), "exclusions.yml"), required=True, help="Relative path to output file where we want to store the exclusions template.")
 @click.option("--verbose", "-v", "verbosity", count=True)
 def create_exclusions_file(output_file: str, verbosity: int) -> None:
     """
@@ -38,11 +30,10 @@ def create_exclusions_file(output_file: str, verbosity: int) -> None:
     """
     set_log_level(verbosity)
 
-    filename = Path(output_file).resolve()
-    with open(filename, "a") as file_obj:
+    with open(output_file, "a") as file_obj:
         for line in EXCLUSIONS_TEMPLATE:
             file_obj.write(line)
-    utils.print_green(f"Success! Exclusions template file written to: {filename}")
+    utils.print_green(f"Success! Exclusions template file written to: {output_file}")
     print(
         "Make sure you download your account authorization details before running the scan."
         "Set your AWS access keys as environment variables then run: "

--- a/cloudsplaining/command/create_multi_account_config_file.py
+++ b/cloudsplaining/command/create_multi_account_config_file.py
@@ -8,7 +8,6 @@ This way, users don't have to remember exactly how to phrase the yaml files, sin
 # For full license text, see the LICENSE file in the repo root
 # or https://opensource.org/licenses/BSD-3-Clause
 import os
-from pathlib import Path
 import logging
 import click
 from cloudsplaining.shared.constants import MULTI_ACCOUNT_CONFIG_TEMPLATE
@@ -24,41 +23,29 @@ END = "\033[0m"
     context_settings=dict(max_content_width=160),
     short_help="Creates a YML file to be used for multi-account scanning",
 )
-@click.option(
-    "--output-file",
-    "-o",
-    "output_file",
-    type=click.Path(exists=False),
-    default=os.path.join(os.getcwd(), "multi-account-config.yml"),
-    required=True,
-    help="Relative path to output file where we want to store the multi account config template.",
-)
-@click.option(
-    "-v", "--verbose", "verbosity", count=True,
-)
+@click.option("-o", "--output-file", "output_file", type=click.Path(exists=False), default=os.path.join(os.getcwd(), "multi-account-config.yml"), required=True, help="Relative path to output file where we want to store the multi account config template.")
+@click.option("-v", "--verbose", "verbosity", help="Log verbosity level.", count=True)
 def create_multi_account_config_file(output_file: str, verbosity: int) -> None:
     """
     Creates a YML file to be used as a multi-account config template, so users can scan many different accounts.
     """
     set_log_level(verbosity)
 
-    filename = Path(output_file).resolve()
-
-    if filename.exists():
+    if os.path.exists(output_file):
         logger.debug(
-            "%s exists. Removing the file and replacing its contents.", filename
+            "%s exists. Removing the file and replacing its contents.", output_file
         )
-        filename.unlink()
+        os.remove(output_file)
 
-    with open(filename, "a") as file_obj:
+    with open(output_file, "a") as file_obj:
         for line in MULTI_ACCOUNT_CONFIG_TEMPLATE:
             file_obj.write(line)
     utils.print_green(
-        f"Success! Multi-account config file written to: {os.path.relpath(filename)}"
+        f"Success! Multi-account config file written to: {os.path.relpath(output_file)}"
     )
     print(
-        f"\nMake sure you edit the {os.path.relpath(filename)} file and then run the scan-multi-account command, as shown below."
+        f"\nMake sure you edit the {os.path.relpath(output_file)} file and then run the scan-multi-account command, as shown below."
     )
     print(
-        f"\n\tcloudsplaining scan-multi-account --exclusions-file exclusions.yml -c {os.path.relpath(filename)} -o ./"
+        f"\n\tcloudsplaining scan-multi-account --exclusions-file exclusions.yml -c {os.path.relpath(output_file)} -o ./"
     )

--- a/cloudsplaining/command/expand_policy.py
+++ b/cloudsplaining/command/expand_policy.py
@@ -18,14 +18,8 @@ logger = logging.getLogger(__name__)
 @click.command(
     short_help="Expand the * Actions in IAM policy files to improve readability"
 )
-@click.option(
-    "--input-file",
-    "-i",
-    type=click.Path(exists=True),
-    required=True,
-    help="Path to the JSON policy file.",
-)
-@click.option("--verbose", "-v", "verbosity", count=True)
+@click.option("-i", "--input-file", type=click.Path(exists=True), required=True, help="Path to the JSON policy file.")
+@click.option("-v", "--verbose", "verbosity", help="Log verbosity level.", count=True)
 def expand_policy(input_file: str, verbosity: int) -> None:
     """
     Expand the * Actions in IAM policy files to improve readability

--- a/cloudsplaining/command/scan.py
+++ b/cloudsplaining/command/scan.py
@@ -24,54 +24,17 @@ from cloudsplaining.shared.utils import write_results_data_file
 from cloudsplaining.output.report import HTMLReport
 from cloudsplaining import set_log_level
 
-logger = logging.getLogger(__name__)
-
 
 @click.command(
     short_help="Scan a single file containing AWS IAM account authorization details and generate report on "
     "IAM security posture. "
 )
-@click.option(
-    "--input-file",
-    "-i",
-    type=click.Path(exists=True),
-    required=True,
-    help="Path of IAM account authorization details file",
-)
-@click.option(
-    "--exclusions-file",
-    "-e",
-    help="A yaml file containing a list of policy names to exclude from the scan.",
-    type=click.Path(exists=True),
-    required=False,
-    default=EXCLUSIONS_FILE,
-)
-@click.option(
-    "--output",
-    "-o",
-    required=False,
-    type=click.Path(exists=True),
-    default=os.getcwd(),
-    help="Output directory.",
-)
-@click.option(
-    "--skip-open-report",
-    "-s",
-    required=False,
-    default=False,
-    is_flag=True,
-    help="Don't open the HTML report in the web browser after creating. "
-    "This helps when running the report in automation.",
-)
-@click.option(
-    "--minimize",
-    "-m",
-    required=False,
-    default=False,
-    is_flag=True,
-    help="Reduce the size of the HTML Report by pulling the Cloudsplaining Javascript code over the internet.",
-)
-@click.option("--verbose", "-v", "verbosity", count=True)
+@click.option("-i", "--input-file", type=click.Path(exists=True), required=True, help="Path of IAM account authorization details file")
+@click.option("-e", "--exclusions-file", help="A yaml file containing a list of policy names to exclude from the scan.", type=click.Path(exists=True), required=False, default=EXCLUSIONS_FILE)
+@click.option("-o", "--output", required=False, type=click.Path(exists=True), default=os.getcwd(), help="Output directory.")
+@click.option("-s", "--skip-open-report", required=False, default=False, is_flag=True, help="Don't open the HTML report in the web browser after creating. This helps when running the report in automation.")
+@click.option("-m", "--minimize", required=False, default=False, is_flag=True, help="Reduce the size of the HTML Report by pulling the Cloudsplaining Javascript code over the internet.")
+@click.option("-v", "--verbose", "verbosity", help="Log verbosity level.", count=True)
 def scan(
     input_file: str,
     exclusions_file: str,
@@ -98,7 +61,7 @@ def scan(
         exclusions = DEFAULT_EXCLUSIONS
 
     if os.path.isfile(input_file):
-        account_name = Path(input_file).stem
+        account_name = os.path.basename(input_file).split(".")[0]
         with open(input_file) as f:
             contents = f.read()
             account_authorization_details_cfg = json.loads(contents)
@@ -137,7 +100,7 @@ def scan(
                 contents = f.read()
                 account_authorization_details_cfg = json.loads(contents)
 
-            account_name = Path(file).stem
+            account_name = os.path.basename(input_file).split(".")[0]
             # Scan the Account Authorization Details config
             rendered_html_report = scan_account_authorization_details(
                 account_authorization_details_cfg,
@@ -162,6 +125,9 @@ def scan(
                 print("Opening the HTML report")
                 url = "file://%s" % os.path.abspath(html_output_file)
                 webbrowser.open(url, new=2)
+
+
+logger = logging.getLogger(__name__)
 
 
 def scan_account_authorization_details(

--- a/cloudsplaining/command/scan_multi_account.py
+++ b/cloudsplaining/command/scan_multi_account.py
@@ -41,71 +41,16 @@ class MultiAccountConfig:
 
 
 @click.command(short_help="Scan multiple AWS Accounts using a config file")
-@click.option(
-    "--config",
-    "-c",
-    "config_file",
-    type=click.Path(exists=True),
-    required=True,
-    help="Path of the multi-account config file",
-)
-@click.option(
-    "--profile",
-    "-p",
-    "profile",
-    type=str,
-    required=False,
-    help="Specify the AWS IAM profile.",
-    envvar="AWS_PROFILE",
-)
-@click.option(
-    "--role-name",
-    "-r",
-    "role_name",
-    type=str,
-    required=True,
-    help="The name of the IAM role to assume in target accounts. Must be the same name in all target accounts.",
-)
-@click.option(
-    "--exclusions-file",
-    "-e",
-    "exclusions_file",
-    help="A yaml file containing a list of policy names to exclude from the scan.",
-    type=click.Path(exists=True),
-    required=False,
-    default=EXCLUSIONS_FILE,
-)
-@optgroup.group(
-    "Output Target Options", help="",
-)
-@optgroup.option(
-    "--output-directory",
-    "-o",
-    "output_directory",
-    type=click.Path(exists=True),
-    help="Output directory. Supply this and/or --bucket.",
-)
-@optgroup.option(
-    "--output-bucket",
-    "-b",
-    "output_bucket",
-    type=str,
-    help="The S3 bucket to save the results. Supply this and/or --output-directory.",
-)
-@optgroup.group(
-    "Other Options", help="",
-)
-@optgroup.option(
-    "--write-data-file",
-    "-w",
-    is_flag=True,
-    required=False,
-    default=False,
-    help="Save the cloudsplaining JSON-formatted data results.",
-)
-@click.option(
-    "-v", "--verbose", "verbosity", count=True,
-)
+@click.option("--config", "-c", "config_file", type=click.Path(exists=True), required=True, help="Path of the multi-account config file")
+@click.option("-p", "--profile", type=str, required=False, envvar="AWS_DEFAULT_PROFILE", help="Specify the AWS IAM profile")
+@click.option("-r", "--role-name", "role_name", type=str, required=True, help="The name of the IAM role to assume in target accounts. Must be the same name in all target accounts.")
+@click.option("-e", "--exclusions-file", "exclusions_file", help="A yaml file containing a list of policy names to exclude from the scan.", type=click.Path(exists=True), required=False, default=EXCLUSIONS_FILE)
+@optgroup.group("Output Target Options", help="")
+@optgroup.option("-o", "--output-directory", "output_directory", type=click.Path(exists=True), help="Output directory. Supply this and/or --bucket.")
+@optgroup.option("-b", "--output-bucket", "output_bucket", type=str, help="The S3 bucket to save the results. Supply this and/or --output-directory.")
+@optgroup.group("Other Options", help="")
+@optgroup.option("-w", "--write-data-file", is_flag=True, required=False, default=False, help="Save the cloudsplaining JSON-formatted data results.")
+@click.option("-v", "--verbose", "verbosity", help="Log verbosity level.", count=True)
 def scan_multi_account(
     config_file: str,
     profile: str,
@@ -191,8 +136,8 @@ def scan_accounts(
                 )
         if output_directory:
             # Write the HTML file
-            html_output_file = Path(output_directory) / f"{target_account_name}.html"
-            html_output_file.write_text(rendered_report)
+            html_output_file = os.path.join(output_directory, f"{target_account_name}.html")
+            utils.write_file(html_output_file, rendered_report)
             utils.print_green(
                 f"Saved the HTML report to: {os.path.relpath(html_output_file)}"
             )

--- a/cloudsplaining/command/scan_policy_file.py
+++ b/cloudsplaining/command/scan_policy_file.py
@@ -28,29 +28,9 @@ END = "\033[0m"
 @click.command(
     short_help="Scan a single policy file to identify identify missing resource constraints."
 )
-@click.option(
-    "--input-file",
-    "-i",
-    type=str,
-    # required=True,
-    help="Path of the IAM policy file to evaluate.",
-)
-@click.option(
-    "--exclusions-file",
-    "-e",
-    help="A yaml file containing a list of actions to ignore when scanning.",
-    type=click.Path(exists=True),
-    required=False,
-    default=EXCLUSIONS_FILE,
-)
-@click.option(
-    "--high-priority-only",
-    required=False,
-    default=False,
-    is_flag=True,
-    help="If issues are found, only print the high priority risks"
-    " (Resource Exposure, Privilege Escalation, Data Exfiltration). This can help with prioritization.",
-)
+@click.option("-i", "--input-file", type=str, help="Path of the IAM policy file to evaluate.")
+@click.option("-e", "--exclusions-file", help="A yaml file containing a list of actions to ignore when scanning.", type=click.Path(exists=True), required=False, default=EXCLUSIONS_FILE)
+@click.option("--high-priority-only", required=False, default=False, is_flag=True, help="If issues are found, only print the high priority risks (Resource Exposure, Privilege Escalation, Data Exfiltration). This can help with prioritization.")
 @click.option("--verbose", "-v", "verbosity", count=True)
 # pylint: disable=redefined-builtin
 def scan_policy_file(

--- a/cloudsplaining/shared/utils.py
+++ b/cloudsplaining/shared/utils.py
@@ -4,6 +4,7 @@
 # Licensed under the BSD 3-Clause license.
 # For full license text, see the LICENSE file in the repo root
 # or https://opensource.org/licenses/BSD-3-Clause
+import os
 import json
 import logging
 from hashlib import sha256
@@ -130,7 +131,8 @@ def write_results_data_file(
     :return:
     """
     # Write the output to a results file if that was specified. Otherwise, just print to stdout
-    Path(raw_data_file).write_text(json.dumps(results, indent=4, default=str))
+    with open(raw_data_file, "w") as f:
+        f.write(json.dumps(results, indent=4, default=str))
     return raw_data_file
 
 
@@ -148,3 +150,21 @@ def print_green(string: Any) -> None:
 def print_grey(string: Any) -> None:
     """Print grey text"""
     print(f"{GREY}{string}{END}")
+
+
+def write_file(file: str, content: str) -> None:
+    if os.path.exists(file):
+        logger.debug("%s exists. Removing the file and replacing its contents." % file)
+        os.remove(file)
+    with open(file, "w") as f:
+        f.write(content)
+
+
+def write_json_to_file(file: str, content: str) -> None:
+    if os.path.exists(file):
+        logger.debug("%s exists. Removing the file and replacing its contents." % file)
+        os.remove(file)
+
+    with open(file, "w") as f:
+        json.dump(content, f, indent=4, default=str)
+


### PR DESCRIPTION
## What does this PR do?

* `AWS_DEFAULT_PROFILE` is now respected by the `download` and `scan-multi-account` command. The downloaded filename also respects this instead of using "default" a bunch. Fixes #237
* Made some formatting updates to the use of Path which should help some of the windows issues. Fixes #236

## Completion checklist

- [x] Additions and changes have unit tests
- [x] The pull request has been appropriately labeled using the provided PR labels
- [x] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [ ] If the UI contents or JavaScript files have been modified, generate a new example report:

```bash
# Generate the updated Javascript bundle
make build-js

# Generate the example report
make generate-report
```

