### PR TITLE
Ability to return json results when used as python lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -381,3 +381,4 @@ Try upgrading to the latest version of Cloudsplaining. This error was fixed in v
 * [AWS Privilege Escalation Methods](https://github.com/RhinoSecurityLabs/AWS-IAM-Privilege-Escalation) by [Spencer Gietzen](https://twitter.com/SpenGietz) at Rhino Security Labs
 * [Understanding Access Level Summaries within Policy Summaries](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_understand-policy-summary-access-level-summaries.html)
 * [Leveraging next-generation blockchain-based AI across multiple service meshes to transparently automate multi-cloud IAM wizardry :mage_man:](http://kmcquade.com/rick.html)
+

--- a/cloudsplaining/command/scan.py
+++ b/cloudsplaining/command/scan.py
@@ -138,7 +138,7 @@ def scan_account_authorization_details(
     write_data_files: bool = False,
     minimize: bool = False,
     return_json_results: bool = False
-) -> any:  # pragma: no cover
+) -> Any:  # pragma: no cover
     """
     Given the path to account authorization details files and the exclusions config file, scan all inline and
     managed policies in the account to identify actions that do not leverage resource constraints.

--- a/cloudsplaining/command/scan.py
+++ b/cloudsplaining/command/scan.py
@@ -137,7 +137,8 @@ def scan_account_authorization_details(
     output_directory: str = os.getcwd(),
     write_data_files: bool = False,
     minimize: bool = False,
-) -> str:  # pragma: no cover
+    return_json_results: bool = False
+) -> any:  # pragma: no cover
     """
     Given the path to account authorization details files and the exclusions config file, scan all inline and
     managed policies in the account to identify actions that do not leverage resource constraints.
@@ -187,7 +188,14 @@ def scan_account_authorization_details(
         findings_data_filepath = write_results_data_file(results, findings_data_file)
         print(f"Findings data file saved: {findings_data_filepath}")
 
-    return rendered_report
+    if return_json_results:
+        return {
+            "iam_results" : authorization_details.results,
+            "iam_findings" : results,
+            "rendered_report" : rendered_report
+        }
+    else:
+        return rendered_report
 
 
 def get_authorization_files_in_directory(


### PR DESCRIPTION
Modified file : '/cloudsplaining/command/scan.py'
Modified Function : scan_account_authorization_details


## What does this PR do?

It allows to get json results from the scan_account_authorization_details when used as python library. It helps in programmatically using the output for further actions where writing to a file is not available.

Need to change the return type of the function as it returns json.
Added return_json_results parameter to return json only if required and the update does not break existing implementations. 
Return a json object with rendered html report string and json results if the return_json_results parameter is set as True 

