### PR TITLE
Optionally allow noisy results to flag risky actions regardless of resource constraints or conditions usage

### DIFF
--- a/cloudsplaining/command/scan_policy_file.py
+++ b/cloudsplaining/command/scan_policy_file.py
@@ -31,10 +31,11 @@ END = "\033[0m"
 @click.option("-i", "--input-file", type=str, help="Path of the IAM policy file to evaluate.")
 @click.option("-e", "--exclusions-file", help="A yaml file containing a list of actions to ignore when scanning.", type=click.Path(exists=True), required=False, default=EXCLUSIONS_FILE)
 @click.option("--high-priority-only", required=False, default=False, is_flag=True, help="If issues are found, only print the high priority risks (Resource Exposure, Privilege Escalation, Data Exfiltration). This can help with prioritization.")
+@click.option("-aR", "--flag-all-risky-actions", is_flag=True, help="Flag all risky actions, regardless of whether resource ARN constraints or conditions are used.")
 @click.option("--verbose", "-v", "verbosity", count=True)
 # pylint: disable=redefined-builtin
 def scan_policy_file(
-    input_file: str, exclusions_file: str, high_priority_only: bool, verbosity: int
+    input_file: str, exclusions_file: str, high_priority_only: bool, flag_all_risky_actions: bool, verbosity: int
 ) -> None:  # pragma: no cover
     """Scan a single policy file to identify missing resource constraints."""
     set_log_level(verbosity)
@@ -57,7 +58,6 @@ def scan_policy_file(
             exclusions_cfg = yaml.safe_load(yaml_file)
         except yaml.YAMLError as exc:
             logger.critical(exc)
-    # exclusions = Exclusions(exclusions_cfg)
 
     # Run the scan and get the raw data.
     results = scan_policy(policy, exclusions_cfg)
@@ -135,15 +135,19 @@ def scan_policy_file(
 def scan_policy(
     policy_json: Dict[str, Any],
     exclusions_config: Dict[str, List[str]] = DEFAULT_EXCLUSIONS_CONFIG,
+    flag_conditional_statements: bool = False,
+    flag_resource_arn_statements: bool = False,
 ) -> Dict[str, Any]:
     """
     Scan a policy document for missing resource constraints.
 
     :param policy_json: Dictionary containing the IAM policy.
     :param exclusions_config: Exclusions configuration. If none, just send an empty dictionary. Defaults to the contents of cloudsplaining.shared.default-exclusions.yml
+    :param flag_resource_arn_statements:
+    :param flag_conditional_statements:
     :return:
     """
-    policy_document = PolicyDocument(policy_json)
     exclusions = Exclusions(exclusions_config)
+    policy_document = PolicyDocument(policy_json, exclusions=exclusions, flag_resource_arn_statements=flag_resource_arn_statements, flag_conditional_statements=flag_conditional_statements)
     policy_finding = PolicyFinding(policy_document, exclusions)
     return policy_finding.results

--- a/cloudsplaining/command/scan_policy_file.py
+++ b/cloudsplaining/command/scan_policy_file.py
@@ -59,8 +59,15 @@ def scan_policy_file(
         except yaml.YAMLError as exc:
             logger.critical(exc)
 
+    if flag_all_risky_actions:
+        flag_conditional_statements = True
+        flag_resource_arn_statements = True
+    else:
+        flag_conditional_statements = False
+        flag_resource_arn_statements = False
+
     # Run the scan and get the raw data.
-    results = scan_policy(policy, exclusions_cfg)
+    results = scan_policy(policy, exclusions_cfg, flag_resource_arn_statements=flag_resource_arn_statements, flag_conditional_statements=flag_conditional_statements)
 
     # There will only be one finding in the results but it is in a list.
     results_exist = 0

--- a/cloudsplaining/scan/authorization_details.py
+++ b/cloudsplaining/scan/authorization_details.py
@@ -29,7 +29,17 @@ class AuthorizationDetails:
         self,
         auth_json: Dict[str, List[Dict[str, Any]]],
         exclusions: Exclusions = DEFAULT_EXCLUSIONS,
+        flag_conditional_statements: bool = False,
+        flag_resource_arn_statements: bool = False,
     ) -> None:
+        """
+        Object to hold and analyze Account Authorization details.
+
+        :param auth_json: the JSON response of the aws iam get-account-authorization-details command
+        :param exclusions: A list of exclusions to apply to the results
+        :param flag_conditional_statements: Flag IAM statements with conditions, not just wildcards
+        :param flag_resource_arn_statements: Flag IAM statements with resource ARN restrictions, not just wildcards
+        """
         self.auth_json = auth_json
 
         if not isinstance(exclusions, Exclusions):
@@ -37,21 +47,25 @@ class AuthorizationDetails:
                 "For exclusions, please provide an object of the Exclusions type"
             )
         self.exclusions = exclusions
+        self.flag_conditional_statements = flag_conditional_statements
+        self.flag_resource_arn_statements = flag_resource_arn_statements
 
-        self.policies = ManagedPolicyDetails(auth_json.get("Policies", []), exclusions)
+        self.policies = ManagedPolicyDetails(auth_json.get("Policies", []), exclusions, flag_conditional_statements=flag_conditional_statements, flag_resource_arn_statements=flag_resource_arn_statements)
 
         # New Authorization file stuff
         self.group_detail_list = GroupDetailList(
-            auth_json.get("GroupDetailList", []), self.policies, exclusions
+            auth_json.get("GroupDetailList", []), self.policies, exclusions, flag_conditional_statements=flag_conditional_statements, flag_resource_arn_statements=flag_resource_arn_statements
         )
         self.user_detail_list = UserDetailList(
             auth_json.get("UserDetailList", []),
             self.policies,
             self.group_detail_list,
             exclusions,
+            flag_conditional_statements=flag_conditional_statements,
+            flag_resource_arn_statements=flag_resource_arn_statements
         )
         self.role_detail_list = RoleDetailList(
-            auth_json.get("RoleDetailList", []), self.policies, exclusions
+            auth_json.get("RoleDetailList", []), self.policies, exclusions, flag_conditional_statements=flag_conditional_statements, flag_resource_arn_statements=flag_resource_arn_statements
         )
 
     @property

--- a/cloudsplaining/scan/inline_policy.py
+++ b/cloudsplaining/scan/inline_policy.py
@@ -13,7 +13,9 @@ class InlinePolicy:
     """
 
     def __init__(
-        self, policy_detail: Dict[str, Any], exclusions: Exclusions = DEFAULT_EXCLUSIONS
+        self, policy_detail: Dict[str, Any], exclusions: Exclusions = DEFAULT_EXCLUSIONS,
+        flag_conditional_statements: bool = False,
+        flag_resource_arn_statements: bool = False,
     ) -> None:
         """
         Initialize the InlinePolicy object.
@@ -25,9 +27,15 @@ class InlinePolicy:
                 "The exclusions provided is not an Exclusions type object. "
                 "Please supply an Exclusions object and try again."
             )
+        # Fix Issue #254 - Allow flagging risky actions even when there are resource constraints
+        self.flag_conditional_statements = flag_conditional_statements
+        self.flag_resource_arn_statements = flag_resource_arn_statements
+
         self.policy_name = policy_detail.get("PolicyName", "")
         self.policy_document = PolicyDocument(
-            cast(Dict[str, Any], policy_detail.get("PolicyDocument")), exclusions
+            cast(Dict[str, Any], policy_detail.get("PolicyDocument")), exclusions=exclusions,
+            flag_conditional_statements=flag_conditional_statements,
+            flag_resource_arn_statements=flag_resource_arn_statements
         )
         # Generating the provider ID based on a string representation of the Policy Document,
         # to avoid collisions where there are inline policies with the same name but different contents

--- a/cloudsplaining/scan/managed_policy_detail.py
+++ b/cloudsplaining/scan/managed_policy_detail.py
@@ -28,6 +28,8 @@ class ManagedPolicyDetails:
         self,
         policy_details: List[Dict[str, Any]],
         exclusions: Exclusions = DEFAULT_EXCLUSIONS,
+        flag_conditional_statements: bool = False,
+        flag_resource_arn_statements: bool = False,
     ) -> None:
         self.policy_details = []
         if not isinstance(exclusions, Exclusions):
@@ -36,6 +38,8 @@ class ManagedPolicyDetails:
                 "Please supply an Exclusions object and try again."
             )
         self.exclusions = exclusions
+        self.flag_conditional_statements = flag_conditional_statements
+        self.flag_resource_arn_statements = flag_resource_arn_statements
 
         for policy_detail in policy_details:
             this_policy_name = policy_detail["PolicyName"]
@@ -66,7 +70,7 @@ class ManagedPolicyDetails:
                     this_policy_path,
                 )
                 continue
-            self.policy_details.append(ManagedPolicy(policy_detail, exclusions))
+            self.policy_details.append(ManagedPolicy(policy_detail, exclusions=exclusions, flag_resource_arn_statements=self.flag_resource_arn_statements, flag_conditional_statements=self.flag_conditional_statements))
 
     def get_policy_detail(self, arn: str) -> "ManagedPolicy":
         """Get a ManagedPolicy object by providing the ARN. This is useful to PrincipalDetail objects"""
@@ -125,10 +129,15 @@ class ManagedPolicy:
     """
 
     def __init__(
-        self, policy_detail: Dict[str, Any], exclusions: Exclusions = DEFAULT_EXCLUSIONS
+        self, policy_detail: Dict[str, Any], exclusions: Exclusions = DEFAULT_EXCLUSIONS,
+        flag_conditional_statements: bool = False,
+        flag_resource_arn_statements: bool = False,
     ) -> None:
         # Store the Raw JSON data from this for safekeeping
         self.policy_detail = policy_detail
+
+        self.flag_conditional_statements = flag_conditional_statements
+        self.flag_resource_arn_statements = flag_resource_arn_statements
 
         # Store the attributes per Policy item
         self.policy_name = policy_detail["PolicyName"]
@@ -172,7 +181,7 @@ class ManagedPolicy:
         for policy_version in self.policy_version_list:
             if policy_version.get("IsDefaultVersion") is True:
                 return PolicyDocument(
-                    policy_version.get("Document"), exclusions=self.exclusions
+                    policy_version.get("Document"), exclusions=self.exclusions, flag_resource_arn_statements=self.flag_resource_arn_statements, flag_conditional_statements=self.flag_conditional_statements
                 )
         raise Exception(
             "Managed Policy ARN %s has no default Policy Document version", self.arn

--- a/cloudsplaining/scan/policy_document.py
+++ b/cloudsplaining/scan/policy_document.py
@@ -130,6 +130,7 @@ class PolicyDocument:
                 ):
                     if action.lower() not in self.exclusions.exclude_actions:
                         actions_missing_resource_constraints.append(action)
+        actions_missing_resource_constraints.sort()
         return actions_missing_resource_constraints
 
     @property
@@ -234,8 +235,9 @@ class PolicyDocument:
                 allowed.add(unrestricted_actions_lower[specific_action_lower])
             elif specific_action_lower in unrestrictable_actions_lower:
                 allowed.add(unrestrictable_actions_lower[specific_action_lower])
-
-        return list(allowed)
+        results = list(allowed)
+        results.sort()
+        return results
 
     @property
     def allows_data_exfiltration_actions(self) -> List[str]:

--- a/cloudsplaining/scan/statement_detail.py
+++ b/cloudsplaining/scan/statement_detail.py
@@ -205,6 +205,7 @@ class StatementDetail:
             result = remove_actions_not_matching_access_level(
                 self.restrictable_actions, "Permissions management"
             )
+        result.sort()
         return result
 
     @property
@@ -220,6 +221,7 @@ class StatementDetail:
             result = remove_actions_not_matching_access_level(
                 self.restrictable_actions, "Write"
             )
+        result.sort()
         return result
 
     @property
@@ -251,7 +253,9 @@ class StatementDetail:
             actions_missing_resource_constraints = self.restrictable_actions
         else:
             pass
-        return exclusions.get_allowed_actions(actions_missing_resource_constraints)
+        result = exclusions.get_allowed_actions(actions_missing_resource_constraints)
+        result.sort()
+        return result
 
     def missing_resource_constraints_for_modify_actions(
         self, exclusions: Exclusions = DEFAULT_EXCLUSIONS

--- a/cloudsplaining/scan/statement_detail.py
+++ b/cloudsplaining/scan/statement_detail.py
@@ -33,7 +33,7 @@ class StatementDetail:
     Analyzes individual statements within a policy
     """
 
-    def __init__(self, statement: Dict[str, Any]) -> None:
+    def __init__(self, statement: Dict[str, Any], flag_conditional_statements: bool = False, flag_resource_arn_statements: bool = False) -> None:
         self.json = statement
         self.statement = statement
         self.effect = statement["Effect"]
@@ -41,6 +41,10 @@ class StatementDetail:
         self.resources = self._resources()
         self.actions = self._actions()
         self.not_action = self._not_action()
+
+        # Fix Issue #254 - Allow flagging risky actions even when there are resource constraints
+        self.flag_conditional_statements = flag_conditional_statements
+        self.flag_resource_arn_statements = flag_resource_arn_statements
 
         self.has_resource_wildcard = self._has_resource_wildcard()
         self.not_action_effective_actions = self._not_action_effective_actions()
@@ -193,7 +197,11 @@ class StatementDetail:
         """Where applicable, returns a list of 'Permissions management' IAM actions in the statement that
         do not have resource constraints"""
         result = []
-        if not self.has_resource_constraints:
+        if (
+            not self.has_resource_constraints
+            # Fix Issue #254 - Allow flagging risky actions even when there are resource constraints
+            or self.flag_resource_arn_statements
+        ):
             result = remove_actions_not_matching_access_level(
                 self.restrictable_actions, "Permissions management"
             )
@@ -204,7 +212,11 @@ class StatementDetail:
         """Where applicable, returns a list of 'Write' level IAM actions in the statement that
         do not have resource constraints"""
         result = []
-        if not self.has_resource_constraints:
+        if (
+            not self.has_resource_constraints
+            # Fix Issue #254 - Allow flagging risky actions even when there are resource constraints
+            or self.flag_resource_arn_statements
+        ):
             result = remove_actions_not_matching_access_level(
                 self.restrictable_actions, "Write"
             )
@@ -234,6 +246,11 @@ class StatementDetail:
         actions_missing_resource_constraints = []
         if len(self.resources) == 1 and self.resources[0] == "*":
             actions_missing_resource_constraints = self.restrictable_actions
+        # Fix #390 - if flag_resource_arn_statements is True, then let's treat this as missing resource constraints so we can flag the action anyway.
+        elif self.flag_resource_arn_statements:
+            actions_missing_resource_constraints = self.restrictable_actions
+        else:
+            pass
         return exclusions.get_allowed_actions(actions_missing_resource_constraints)
 
     def missing_resource_constraints_for_modify_actions(
@@ -274,6 +291,14 @@ class StatementDetail:
         return list(modify_actions_missing_constraints)
 
     def _has_condition(self) -> bool:
+        # Fix Issue #254 - Allow flagging risky actions even when there are resource constraints
+        # This is kind of silly, but the easiest way to implement a fix. If we say "flag conditional statements",
+        # then let's just mark it as there is no condition, so we don't skip it in the evaluation.
+        # Due to how we have backwards compatibility set up, this will only flag if someone has
+        # "flag_conditional_statements" set to True, so none of the packages dependent on Cloudsplaining will break
+        # due to this change. Apologies for any confusion due to the hackyness.
+        if self.flag_conditional_statements:
+            return False
         if self.condition:
             return True
         return False

--- a/cloudsplaining/scan/user_details.py
+++ b/cloudsplaining/scan/user_details.py
@@ -24,6 +24,8 @@ class UserDetailList:
         policy_details: ManagedPolicyDetails,
         all_group_details: GroupDetailList,
         exclusions: Exclusions = DEFAULT_EXCLUSIONS,
+        flag_conditional_statements: bool = False,
+        flag_resource_arn_statements: bool = False,
     ) -> None:
         if not isinstance(exclusions, Exclusions):
             raise Exception(
@@ -31,6 +33,10 @@ class UserDetailList:
                 "Please supply an Exclusions object and try again."
             )
         self.exclusions = exclusions
+
+        # Fix Issue #254 - Allow flagging risky actions even when there are resource constraints
+        self.flag_conditional_statements = flag_conditional_statements
+        self.flag_resource_arn_statements = flag_resource_arn_statements
 
         self.users = [
             UserDetail(user_detail, policy_details, all_group_details, exclusions)
@@ -94,6 +100,8 @@ class UserDetail:
         policy_details: ManagedPolicyDetails,
         all_group_details: GroupDetailList,
         exclusions: Exclusions = DEFAULT_EXCLUSIONS,
+        flag_conditional_statements: bool = False,
+        flag_resource_arn_statements: bool = False,
     ) -> None:
         """
         Initialize the UserDetail object.
@@ -116,6 +124,10 @@ class UserDetail:
             )
         self.is_excluded = self._is_excluded(exclusions)
 
+        # Fix Issue #254 - Allow flagging risky actions even when there are resource constraints
+        self.flag_conditional_statements = flag_conditional_statements
+        self.flag_resource_arn_statements = flag_resource_arn_statements
+
         # Groups
         self.groups: List[GroupDetail] = []
         group_list = user_detail.get("GroupList")
@@ -136,7 +148,7 @@ class UserDetail:
                     exclusions.is_policy_excluded(policy_name)
                     or exclusions.is_policy_excluded(policy_id)
                 ):
-                    inline_policy = InlinePolicy(policy_detail)
+                    inline_policy = InlinePolicy(policy_detail, exclusions=exclusions, flag_conditional_statements=flag_conditional_statements, flag_resource_arn_statements=flag_resource_arn_statements)
                     self.inline_policies.append(inline_policy)
 
         # Managed Policies (either AWS-managed or Customer managed)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # AWS
-boto3==1.20.16
-botocore==1.23.16
+boto3==1.20.50
+botocore==1.23.50
 # Speeds up IAM logic
 cached-property==1.5.2
 # Command line
@@ -12,6 +12,6 @@ pyyaml==6.0
 # We render Markdown glossary files as HTML in the Cloudsplaining report
 markdown==3.3.6
 # AWS IAM Logic
-policy-sentry==0.11.19
+policy-sentry==0.12.2
 # Schema validation
-schema==0.7.4
+schema==0.7.5

--- a/test/scanning/test_authorization_details.py
+++ b/test/scanning/test_authorization_details.py
@@ -4,315 +4,120 @@ import unittest
 from cloudsplaining.scan.authorization_details import AuthorizationDetails
 from cloudsplaining.shared.exclusions import Exclusions
 
-# Example test file v2
-example_authz_details_for_overrides_complete_file = os.path.abspath(
-    os.path.join(
-        os.path.dirname(__file__),
-        os.path.pardir,
-        "files",
-        "example_authz_details_for_overrides_complete.json",
-    )
-)
 
-with open(example_authz_details_for_overrides_complete_file) as f:
-    contents = f.read()
-    example_authz_details_for_overrides_complete = json.loads(contents)
+def get_authorization_details_with_example_policy(policy_document_dict: dict) -> dict:
+    """Returns an Authorization details JSON with an example policy as the single policy"""
+
+    authz_details = {
+        "UserDetailList": [
+            {
+                "Path": "/",
+                "UserName": "Captain",
+                "UserId": "Captain",
+                "Arn": "arn:aws:iam::111122223333:user/Captain",
+                "CreateDate": "2019-12-18 19:10:08+00:00",
+                "GroupList": [],
+                "AttachedManagedPolicies": [
+                    {
+                        "PolicyName": "SomePolicy",
+                        "PolicyArn": "arn:aws:iam::111122223333:policy/SomePolicy"
+                    }
+                ],
+                "Tags": []
+            }
+        ],
+        "GroupDetailList": [],
+        "RoleDetailList": [],
+        "Policies": [
+            {
+                "PolicyName": "SomePolicy",
+                "PolicyId": "SomePolicy",
+                "Arn": "arn:aws:iam::111122223333:policy/SomePolicy",
+                "Path": "/",
+                "DefaultVersionId": "v9",
+                "AttachmentCount": 1,
+                "PermissionsBoundaryUsageCount": 0,
+                "IsAttachable": True,
+                "CreateDate": "2020-01-29 21:24:20+00:00",
+                "UpdateDate": "2020-01-29 23:23:12+00:00",
+                "PolicyVersionList": [
+                    {
+                        "Document": policy_document_dict,
+                        "VersionId": "v9",
+                        "IsDefaultVersion": True,
+                        "CreateDate": "2020-01-29 23:23:12+00:00"
+                    }
+                ]
+            }
+        ]
+    }
+    return authz_details
 
 
-example_authz_v2_file = os.path.abspath(
-    os.path.join(
-        os.path.dirname(__file__),
-        os.path.pardir,
-        "files",
-        "example_authz_v2.json",
-    )
-)
+class TestAuthorizationFileDetails(unittest.TestCase):
+    def setUp(self) -> None:
+        self.policy_with_resource_constraints = {
+            "Version": "2012-10-17",
+            "Statement": [
+                # Privilege Escalation
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "iam:UpdateAssumeRolePolicy",
+                        "sts:AssumeRole"
+                    ],
+                    "Resource": "arn:aws:iam::111122223333:role/MyRole"
+                },
+                # Data Exfiltration
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:GetObject",
+                    ],
+                    "Resource": "arn:aws:s3:::mybucket/*"
+                },
+                # Resource Expsoure
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "s3:PutBucketAcl",
+                    ],
+                    "Resource": "arn:aws:s3:::mybucket"
+                },
+                # Credentials Exposure
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "iam:UpdateAccessKey",
+                    ],
+                    "Resource": "arn:aws:iam::111122223333:user/MyUser"
+                },
+                # Infrastructure Modification
+                {
+                    "Effect": "Allow",
+                    "Action": [
+                        "ec2:AuthorizeSecurityGroupIngress",
+                    ],
+                    "Resource": "arn:aws:ec2:us-east-1:111122223333:security-group/sg-12345678"
+                }
+            ]
+        }
+        self.authz_json = get_authorization_details_with_example_policy(policy_document_dict=self.policy_with_resource_constraints)
 
-with open(example_authz_v2_file) as f_2:
-    contents_2 = f_2.read()
-    example_authz_v2 = json.loads(contents_2)
+    def test_authorization_details_with_resource_constraints(self):
+        """Case: Authorization details with resource constraints, WITHOUT --flag-all-risky-actions"""
+        authz_details = AuthorizationDetails(auth_json=self.authz_json)
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.credentials_exposure, [])
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.allows_privilege_escalation, [])
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.allows_data_exfiltration_actions, [])
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.permissions_management_without_constraints, [])
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.infrastructure_modification, [])
 
-
-# class TestAuthorizationFileDetails(unittest.TestCase):
-#     def test_authorization_file_details_missing_constraints(self):
-#         authz_file = {
-#             "UserDetailList": [
-#                 {
-#                   "Path": "/",
-#                   "UserName": "BlakeBortles",
-#                   "UserId": "BlakeBortles",
-#                   "Arn": "arn:aws:iam::012345678901:user/BlakeBortles",
-#                   "CreateDate": "2019-12-18 19:10:08+00:00",
-#                   "GroupList": [
-#                     "GOAT"
-#                   ],
-#                   "AttachedManagedPolicies": [
-#                         {
-#                             "PolicyArn": "arn:aws:iam::012345678901:policy/PolicyForTestingOverrides",
-#                             "PolicyName": "PolicyForTestingOverrides"
-#                         },{
-#                             "PolicyArn": "arn:aws:iam::012345678901:policy/NotYourPolicy",
-#                             "PolicyName": "NotYourPolicy"
-#                         }
-#                   ],
-#                   "Tags": []
-#                 }
-#             ],
-#             "GroupDetailList": [],
-#             "RoleDetailList": [],
-#             "Policies": [
-#                 {
-#                     "PolicyName": "NotYourPolicy",
-#                     "PolicyId": "YAAAAASSQUEEEN",
-#                     "Arn": "arn:aws:iam::012345678901:policy/NotYourPolicy",
-#                     "Path": "/",
-#                     "DefaultVersionId": "v9",
-#                     "AttachmentCount": 1,
-#                     "PermissionsBoundaryUsageCount": 0,
-#                     "IsAttachable": True,
-#                     "CreateDate": "2020-01-29 21:24:20+00:00",
-#                     "UpdateDate": "2020-01-29 23:23:12+00:00",
-#                     "PolicyVersionList": [
-#                         {
-#                             "Document": {
-#                                 "Version": "2012-10-17",
-#                                 "Statement": [
-#                                     {
-#                                         "Sid": "VisualEditor0",
-#                                         "Effect": "Allow",
-#                                         "Action": [
-#                                             "ecr:GetAuthorizationToken",
-#                                             "ecr:UploadLayerPart",
-#                                             "ecr:CompleteLayerUpload",
-#                                             "ecr:PutImage"
-#                                         ],
-#                                         "Resource": [
-#                                             "*"
-#                                         ]
-#                                     }
-#                                 ]
-#                             },
-#                             "VersionId": "v9",
-#                             "IsDefaultVersion": True,
-#                             "CreateDate": "2020-01-29 23:23:12+00:00"
-#                         }
-#                     ]
-#                 },
-#                 {
-#                     "PolicyName": "PolicyForTestingOverrides",
-#                     "PolicyId": "PolicyForTestingOverrides",
-#                     "Arn": "arn:aws:iam::012345678901:policy/PolicyForTestingOverrides",
-#                     "Path": "/",
-#                     "DefaultVersionId": "v9",
-#                     "AttachmentCount": 1,
-#                     "PermissionsBoundaryUsageCount": 0,
-#                     "IsAttachable": True,
-#                     "CreateDate": "2020-01-29 21:24:20+00:00",
-#                     "UpdateDate": "2020-01-29 23:23:12+00:00",
-#                     "PolicyVersionList": [
-#                         {
-#                             "Document": {
-#                                 "Version": "2012-10-17",
-#                                 "Statement": [
-#                                     {
-#                                         "Sid": "VisualEditor0",
-#                                         "Effect": "Allow",
-#                                         "Action": [
-#                                             "s3:CreateBucket"
-#                                         ],
-#                                         "Resource": [
-#                                             "arn:aws:s3:::mybucket"
-#                                         ]
-#                                     },
-#                                     {
-#                                         "Sid": "VisualEditor1",
-#                                         "Effect": "Allow",
-#                                         "Action": [
-#                                             "s3:PutObject",
-#                                             "s3:GetObject"
-#                                         ],
-#                                         "Resource": [
-#                                             "*"
-#                                         ]
-#                                     }
-#                                 ]
-#                             },
-#                             "VersionId": "v9",
-#                             "IsDefaultVersion": True,
-#                             "CreateDate": "2020-01-29 23:23:12+00:00"
-#                         }
-#                     ]
-#                 }
-#             ]
-#         }
-#         authorization_details = AuthorizationDetails(authz_file)
-#         results = authorization_details.results
-#         expected_results = {
-#             "groups": {},
-#             "users": {
-#                 "BlakeBortles": {
-#                     "arn": "arn:aws:iam::012345678901:user/BlakeBortles",
-#                     "create_date": "2019-12-18 19:10:08+00:00",
-#                     "id": "BlakeBortles",
-#                     "name": "BlakeBortles",
-#                     "inline_policies": {},
-#                     "groups": {},
-#                     "path": "/",
-#                     "customer_managed_policies": {
-#                         "PolicyForTestingOverrides": "PolicyForTestingOverrides",
-#                         "YAAAAASSQUEEEN": "NotYourPolicy"
-#                     },
-#                     "aws_managed_policies": {},
-#                     "is_excluded": False
-#                 }
-#             },
-#             "roles": {},
-#             "aws_managed_policies": {},
-#             "customer_managed_policies": {
-#                 "YAAAAASSQUEEEN": {
-#                     "PolicyName": "NotYourPolicy",
-#                     "PolicyId": "YAAAAASSQUEEEN",
-#                     "Arn": "arn:aws:iam::012345678901:policy/NotYourPolicy",
-#                     "Path": "/",
-#                     "DefaultVersionId": "v9",
-#                     "AttachmentCount": 1,
-#                     "IsAttachable": True,
-#                     "CreateDate": "2020-01-29 21:24:20+00:00",
-#                     "UpdateDate": "2020-01-29 23:23:12+00:00",
-#                     "PolicyVersionList": [
-#                         {
-#                             "Document": {
-#                                 "Version": "2012-10-17",
-#                                 "Statement": [
-#                                     {
-#                                         "Sid": "VisualEditor0",
-#                                         "Effect": "Allow",
-#                                         "Action": [
-#                                             "ecr:GetAuthorizationToken",
-#                                             "ecr:UploadLayerPart",
-#                                             "ecr:CompleteLayerUpload",
-#                                             "ecr:PutImage"
-#                                         ],
-#                                         "Resource": [
-#                                             "*"
-#                                         ]
-#                                     }
-#                                 ]
-#                             },
-#                             "VersionId": "v9",
-#                             "IsDefaultVersion": True,
-#                             "CreateDate": "2020-01-29 23:23:12+00:00"
-#                         }
-#                     ],
-#                     "PrivilegeEscalation": [],
-#                     "DataExfiltration": [],
-#                     "ResourceExposure": [],
-#                     "ServiceWildcard": [],
-#                     "CredentialsExposure": [
-#                         "ecr:GetAuthorizationToken"
-#                     ],
-#                     "InfrastructureModification": [
-#                         "ecr:CompleteLayerUpload",
-#                         "ecr:PutImage",
-#                         "ecr:UploadLayerPart"
-#                     ],
-#                     "is_excluded": False
-#                 },
-#                 "PolicyForTestingOverrides": {
-#                     "PolicyName": "PolicyForTestingOverrides",
-#                     "PolicyId": "PolicyForTestingOverrides",
-#                     "Arn": "arn:aws:iam::012345678901:policy/PolicyForTestingOverrides",
-#                     "Path": "/",
-#                     "DefaultVersionId": "v9",
-#                     "AttachmentCount": 1,
-#                     "IsAttachable": True,
-#                     "CreateDate": "2020-01-29 21:24:20+00:00",
-#                     "UpdateDate": "2020-01-29 23:23:12+00:00",
-#                     "PolicyVersionList": [
-#                         {
-#                             "Document": {
-#                                 "Version": "2012-10-17",
-#                                 "Statement": [
-#                                     {
-#                                         "Sid": "VisualEditor0",
-#                                         "Effect": "Allow",
-#                                         "Action": [
-#                                             "s3:CreateBucket"
-#                                         ],
-#                                         "Resource": [
-#                                             "arn:aws:s3:::mybucket"
-#                                         ]
-#                                     },
-#                                     {
-#                                         "Sid": "VisualEditor1",
-#                                         "Effect": "Allow",
-#                                         "Action": [
-#                                             "s3:PutObject",
-#                                             "s3:GetObject"
-#                                         ],
-#                                         "Resource": [
-#                                             "*"
-#                                         ]
-#                                     }
-#                                 ]
-#                             },
-#                             "VersionId": "v9",
-#                             "IsDefaultVersion": True,
-#                             "CreateDate": "2020-01-29 23:23:12+00:00"
-#                         }
-#                     ],
-#                     "PrivilegeEscalation": [],
-#                     "DataExfiltration": [
-#                         "s3:GetObject"
-#                     ],
-#                     "ResourceExposure": [],
-#                     "ServiceWildcard": [],
-#                     "CredentialsExposure": [],
-#                     "InfrastructureModification": [
-#                         "s3:GetObject",
-#                         "s3:PutObject"
-#                     ],
-#                     "is_excluded": False
-#                 }
-#             },
-#             "inline_policies": {},
-#             "exclusions": {
-#                 "policies": [
-#                     "AWSServiceRoleFor*",
-#                     "*ServiceRolePolicy",
-#                     "*ServiceLinkedRolePolicy",
-#                     "AdministratorAccess",
-#                     "service-role*",
-#                     "aws-service-role*",
-#                     "/service-role*",
-#                     "/aws-service-role*",
-#                     "MyRole"
-#                 ],
-#                 "roles": [
-#                     "service-role*",
-#                     "aws-service-role*"
-#                 ],
-#                 "users": [
-#                     ""
-#                 ],
-#                 "groups": [
-#                     ""
-#                 ],
-#                 "include-actions": [
-#                     "s3:GetObject",
-#                     "ssm:GetParameter",
-#                     "ssm:GetParameters",
-#                     "ssm:GetParametersByPath",
-#                     "secretsmanager:GetSecretValue",
-#                     "rds:CopyDBSnapshot",
-#                     "rds:CreateDBSnapshot"
-#                 ],
-#                 "exclude-actions": [
-#                     ""
-#                 ]
-#             }
-#         }
-#
-#         # print(json.dumps(results, indent=4))
-#         self.maxDiff = None
-#         self.assertDictEqual(results, expected_results)
+    def test_authorization_details_flag_all_risky_actions(self):
+        """Case: Authorization details with resource constraints, WITH --flag-all-risky-actions"""
+        authz_details = AuthorizationDetails(auth_json=self.authz_json, flag_resource_arn_statements=True, flag_conditional_statements=True)
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.credentials_exposure, ['iam:UpdateAccessKey', 'sts:AssumeRole'])
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.allows_privilege_escalation, [{'type': 'UpdateRolePolicyToAssumeIt', 'actions': ['iam:updateassumerolepolicy', 'sts:assumerole']}])
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.allows_data_exfiltration_actions, ['s3:GetObject'])
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.permissions_management_without_constraints, ['iam:UpdateAssumeRolePolicy', 's3:PutBucketAcl', 'iam:UpdateAccessKey'])
+        self.assertListEqual(authz_details.policies.policy_details[0].policy_document.infrastructure_modification, ['ec2:AuthorizeSecurityGroupIngress', 'iam:UpdateAccessKey', 'iam:UpdateAssumeRolePolicy', 's3:GetObject', 's3:PutBucketAcl', 'sts:AssumeRole'])

--- a/test/scanning/test_policy_document.py
+++ b/test/scanning/test_policy_document.py
@@ -517,7 +517,7 @@ class TestPolicyDocument(unittest.TestCase):
             ]
         }
         policy_document = PolicyDocument(test_policy, flag_resource_arn_statements=True)
-        self.assertListEqual(policy_document.allows_data_exfiltration_actions, ['iam:UpdateAccessKey'])
+        self.assertListEqual(policy_document.allows_data_exfiltration_actions, ['s3:GetObject'])
         policy_document = PolicyDocument(test_policy, flag_resource_arn_statements=False)
         self.assertListEqual(policy_document.allows_data_exfiltration_actions, [])
 


### PR DESCRIPTION
## What does this PR do?

* Fixes #254
* This PR allows you to specify `--flag-all-risky-actions` so it flags all risky actions, regardless of whether or not they have resource constraints or conditions usage.
* when I get credentials with privileges as an attacker, sometimes s3:GetObject is useful even if it is restricted to a resource ARN. The results will be noisy but helpful to an attacker.

## What gif best describes this PR or how it makes you feel?

![image](https://user-images.githubusercontent.com/3422255/153072530-198e1b47-fc54-4cb0-9e85-4347031d9718.png)

## Completion checklist

- [x] Additions and changes have unit tests
- [x] The pull request has been appropriately labeled using the provided PR labels
- [x] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [x] If the UI contents or JavaScript files have been modified, generate a new example report:

```bash
# Generate the updated Javascript bundle
make build-js

# Generate the example report
make generate-report
```

