### PR TITLE
Suppress findings when conditions exist, except when `--flag-all-risky-actions` flag is included

### DIFF
--- a/cloudsplaining/command/scan.py
+++ b/cloudsplaining/command/scan.py
@@ -35,7 +35,7 @@ from cloudsplaining import set_log_level
 @click.option("-o", "--output", required=False, type=click.Path(exists=True), default=os.getcwd(), help="Output directory.")
 @click.option("-s", "--skip-open-report", required=False, default=False, is_flag=True, help="Don't open the HTML report in the web browser after creating. This helps when running the report in automation.")
 @click.option("-m", "--minimize", required=False, default=False, is_flag=True, help="Reduce the size of the HTML Report by pulling the Cloudsplaining Javascript code over the internet.")
-@click.option("-aR", "--flag-all-risky-actions", is_flag=True, help="Flag all risky actions, regardless of whether resource ARN constraints or conditions are used.")
+@click.option("-aR", "--flag-all-risky-actions", required=False, default=False, is_flag=True, help="Flag all risky actions, regardless of whether resource ARN constraints or conditions are used.")
 @click.option("-v", "--verbose", "verbosity", help="Log verbosity level.", count=True)
 @click.option("-f", "--filter-severity", "severity", help="Filter the severity of findings to be reported.", multiple=True,type=click.Choice(['CRITICAL','HIGH', 'MEDIUM','LOW','NONE'], case_sensitive=False))
 

--- a/cloudsplaining/command/scan_policy_file.py
+++ b/cloudsplaining/command/scan_policy_file.py
@@ -49,6 +49,8 @@ END = "\033[0m"
 @click.option(
     "-aR",
     "--flag-all-risky-actions",
+    required=False,
+    default=False,
     is_flag=True,
     help="Flag all risky actions, regardless of whether resource ARN constraints or conditions are used.",
 )

--- a/cloudsplaining/output/policy_finding.py
+++ b/cloudsplaining/output/policy_finding.py
@@ -52,7 +52,7 @@ class PolicyFinding:
         actions_missing_resource_constraints = set()
         for statement in self.policy_document.statements:
             logger.debug("Evaluating statement: %s", statement.json)
-            if statement.effect == "Allow":
+            if statement.effect == "Allow" and not statement.has_condition:
                 actions_missing_resource_constraints.update(
                     statement.missing_resource_constraints_for_modify_actions(
                         self.exclusions

--- a/cloudsplaining/scan/inline_policy.py
+++ b/cloudsplaining/scan/inline_policy.py
@@ -66,7 +66,7 @@ class InlinePolicy:
             or exclusions.is_policy_excluded(self.policy_id)
         )
 
-    def getFindingLinks(self, findings: Any) -> List[Any]:
+    def getFindingLinks(self, findings: List[Dict[str, Any]]) -> Dict[str, str]:
         links = {}
         for finding in findings:
             links[

--- a/cloudsplaining/scan/inline_policy.py
+++ b/cloudsplaining/scan/inline_policy.py
@@ -67,7 +67,7 @@ class InlinePolicy:
         )
 
     def getFindingLinks(self, findings: Any) -> List[Any]:
-        links: List[Any] = []
+        links = {}
         for finding in findings:
             links[
                 finding["type"]

--- a/cloudsplaining/scan/policy_document.py
+++ b/cloudsplaining/scan/policy_document.py
@@ -125,7 +125,7 @@ class PolicyDocument:
         """Return a list of modify only missing resource constraints"""
         actions_missing_resource_constraints = []
         for statement in self.statements:
-            if statement.effect == "Allow":
+            if statement.effect == "Allow" and not statement.has_condition:
                 for action in statement.missing_resource_constraints_for_modify_actions(
                     self.exclusions
                 ):
@@ -272,7 +272,7 @@ class PolicyDocument:
 
         for statement in self.statements:
             logger.debug("Evaluating statement: %s", statement.json)
-            if statement.effect_allow:
+            if statement.effect_allow and not statement.has_condition:
                 if isinstance(statement.actions, list):
                     for action in statement.actions:
                         # If the action is a straight up *

--- a/cloudsplaining/scan/statement_detail.py
+++ b/cloudsplaining/scan/statement_detail.py
@@ -198,9 +198,8 @@ class StatementDetail:
         do not have resource constraints"""
         result = []
         if (
-            not self.has_resource_constraints
-            # Fix Issue #254 - Allow flagging risky actions even when there are resource constraints
-            or self.flag_resource_arn_statements
+            (not self.has_resource_constraints or self.flag_resource_arn_statements) and
+             not self.has_condition
         ):
             result = remove_actions_not_matching_access_level(
                 self.restrictable_actions, "Permissions management"
@@ -214,9 +213,8 @@ class StatementDetail:
         do not have resource constraints"""
         result = []
         if (
-            not self.has_resource_constraints
-            # Fix Issue #254 - Allow flagging risky actions even when there are resource constraints
-            or self.flag_resource_arn_statements
+            (not self.has_resource_constraints or self.flag_resource_arn_statements) and
+             not self.has_condition
         ):
             result = remove_actions_not_matching_access_level(
                 self.restrictable_actions, "Write"

--- a/test/files/scanning/test_inline_policy_results.json
+++ b/test/files/scanning/test_inline_policy_results.json
@@ -24,7 +24,7 @@
     "severity": "high",
     "description": "<p>These policies allow a combination of IAM actions that allow a principal with these permissions to escalate their privileges - for example, by creating an access key for another IAM user, or modifying their own permissions. This research was pioneered by Spencer Gietzen at Rhino Security Labs.  Remediation guidance can be found <a href=\"https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/\">here</a>.</p>",
     "findings":[],
-    "links":[]
+    "links":{}
   },
   "DataExfiltration":{
     "severity": "medium",


### PR DESCRIPTION
## What does this PR do?

- Fix https://github.com/salesforce/cloudsplaining/issues/278
  - Conditions on policy now suppress *all* issue types, unless the `--flag-all-risky-actions` switch is set
  - `--flag-all-risky-actions` switch is now available to all scanning commands: `scan`, `scan-multi-account`, and `scan-policy-file`
- Fix https://github.com/salesforce/cloudsplaining/issues/299

## What gif best describes this PR or how it makes you feel?

![](https://media.tenor.com/images/70fdd121bcc0a1b77f0ec503569b5569/tenor.gif)

## Completion checklist

- [x] Additions and changes have unit tests
- [x] The pull request has been appropriately labeled using the provided PR labels
- [x] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- ~~[ ] If the UI contents or JavaScript files have been modified, generate a new example report:~~