### PR TITLE
Support federated principals

### DIFF
--- a/cloudsplaining/scan/assume_role_policy_document.py
+++ b/cloudsplaining/scan/assume_role_policy_document.py
@@ -83,6 +83,8 @@ class AssumeRoleStatement:
         "Principal": ["value"]
         "Principal": { "AWS": "value" }
         "Principal": { "AWS": ["value", "value"] }
+        "Principal": { "Federated": "value" }
+        "Principal": { "Federated": ["value", "value"] }
         "Principal": { "Service": "value" }
         "Principal": { "Service": ["value", "value"] }
         Return: Set of principals
@@ -100,6 +102,12 @@ class AssumeRoleStatement:
                     principals.extend(principal["AWS"])
                 else:
                     principals.append(principal["AWS"])
+
+            if "Federated" in principal:
+                if isinstance(principal["Federated"], list):
+                    principals.extend(principal["Federated"])
+                else:
+                    principals.append(principal["Federated"])
 
             if "Service" in principal:
                 if isinstance(principal["Service"], list):

--- a/test/scanning/test_trust_policies.py
+++ b/test/scanning/test_trust_policies.py
@@ -1,7 +1,5 @@
-from cloudsplaining.scan.assume_role_policy_document import AssumeRoleStatement, AssumeRolePolicyDocument
-import os
+from cloudsplaining.scan.assume_role_policy_document import AssumeRoleStatement
 import unittest
-import json
 
 
 class TestAssumeRole(unittest.TestCase):
@@ -10,6 +8,8 @@ class TestAssumeRole(unittest.TestCase):
     "Principal": ["value"]
     "Principal": { "AWS": "value" }
     "Principal": { "AWS": ["value", "value"] }
+    "Principal": { "Federated": "value" }
+    "Principal": { "Federated": ["value", "value"] }
     "Principal": { "Service": "value" }
     "Principal": { "Service": ["value", "value"] }
     """
@@ -40,8 +40,24 @@ class TestAssumeRole(unittest.TestCase):
             Resource="*",
         )
 
-        # "Principal": { "Service": "value", "AWS": "value" }
+        # "Principal": { "Federated": "value" }
         statement05 = dict(
+            Effect="Allow",
+            Principal={"Federated": "accounts.google.com"},
+            Action=["rds:*"],
+            Resource="*",
+        )
+
+        # "Principal": { "Federated": ["value", "value"] }
+        statement06 = dict(
+            Effect="Allow",
+            Principal={"Federated": ["cognito-identity.amazonaws.com", "www.amazon.com"]},
+            Action=["rds:*"],
+            Resource="*",
+        )
+
+        # "Principal": { "Service": "value", "AWS": "value" }
+        statement07 = dict(
             Effect="Allow",
             Principal={
                 "Service": "lambda.amazonaws.com",
@@ -52,7 +68,7 @@ class TestAssumeRole(unittest.TestCase):
         )
 
         # "Principal": { "Service": ["value", "value"] }
-        statement06 = dict(
+        statement08 = dict(
             Effect="Allow",
             Principal={"Service": ["lambda.amazonaws.com"]},
             Action=["rds:*"],
@@ -63,16 +79,22 @@ class TestAssumeRole(unittest.TestCase):
         assume_role_statement_04 = AssumeRoleStatement(statement04)
         assume_role_statement_05 = AssumeRoleStatement(statement05)
         assume_role_statement_06 = AssumeRoleStatement(statement06)
+        assume_role_statement_07 = AssumeRoleStatement(statement07)
+        assume_role_statement_08 = AssumeRoleStatement(statement08)
 
         self.assertListEqual(assume_role_statement_02.principals, ['arn:aws:iam::012345678910:root'])
         self.assertListEqual(assume_role_statement_03.principals, ['arn:aws:iam::012345678910:root'])
         self.assertListEqual(assume_role_statement_04.principals, ['arn:aws:iam::012345678910:root'])
-        self.assertListEqual(assume_role_statement_05.principals, ['arn:aws:iam::012345678910:root', 'lambda.amazonaws.com'])
-        self.assertListEqual(assume_role_statement_06.principals, ['lambda.amazonaws.com'])
+        self.assertListEqual(assume_role_statement_05.principals, ['accounts.google.com'])
+        self.assertListEqual(assume_role_statement_06.principals, ['cognito-identity.amazonaws.com', 'www.amazon.com'])
+        self.assertListEqual(assume_role_statement_07.principals, ['arn:aws:iam::012345678910:root', 'lambda.amazonaws.com'])
+        self.assertListEqual(assume_role_statement_08.principals, ['lambda.amazonaws.com'])
 
         self.assertListEqual(assume_role_statement_02.role_assumable_by_compute_services, [])
         self.assertListEqual(assume_role_statement_03.role_assumable_by_compute_services, [])
         self.assertListEqual(assume_role_statement_04.role_assumable_by_compute_services, [])
+        self.assertListEqual(assume_role_statement_05.role_assumable_by_compute_services, [])
+        self.assertListEqual(assume_role_statement_06.role_assumable_by_compute_services, [])
         # self.assertListEqual(assume_role_statement_05.role_assumable_by_compute_services, ["lambda"])
         # self.assertListEqual(assume_role_statement_06.role_assumable_by_compute_services, ["lambda"])
 


### PR DESCRIPTION
## What does this PR do?

- Handles federated principals correctly, because currently they are ignored when used in an assume role policy 

## What gif best describes this PR or how it makes you feel?

![](https://media.giphy.com/media/xT5LMtvp5AYLh3ATD2/giphy.gif)

## Completion checklist


- [x] Additions and changes have unit tests
- [ ] The pull request has been appropriately labeled using the provided PR labels
- [ ] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [ ] If the UI contents or JavaScript files have been modified, generate a new example report:

```bash
# Generate the updated Javascript bundle
make build-js

# Generate the example report
make generate-report
```

