### PR TITLE
switch trufflehog action to official one

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -13,6 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332  # v4.1.7
       - name: detect secrets
-        uses: edplato/trufflehog-actions-scan@c36ff9abf0af8290ef23b1b45a36e75c742dd1d8 # v0.9l-beta
+        uses: trufflesecurity/trufflehog@0328a19a9d3877c9f04d0dbee5717aabff5b575d # v3.82.6
         with:
-          scanArguments: "--regex --entropy=False --exclude_paths .github/exclude-patterns.txt --max_depth=1"
+          extra_args: "--exclude_paths .github/exclude-patterns.txt --max_depth=1"


### PR DESCRIPTION
## What does this PR do?

- the unofficial one doesn't work anymore, so why not switch to the official one 😅 

## What gif best describes this PR or how it makes you feel?

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExenB6bGd5NW9hNTUxaDJibXd4b2pya29kcGJsamFsb2F0dzhjYXJkeCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/mYVpxVU9J0L0k/giphy.gif)

## Completion checklist


- [ ] Additions and changes have unit tests
- [x] The pull request has been appropriately labeled using the provided PR labels
- [ ] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [ ] If the UI contents or JavaScript files have been modified, generate a new example report:

```bash
# Generate the updated Javascript bundle
make build-js

# Generate the example report
make generate-report
```

