### PR TITLE
 feat : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apk add nodejs==18.16.0-r0
 RUN apk add npm==9.1.2-r0
 RUN apk add make==4.3-r1
 ###### install requirements.txt
-RUN python3 -m pip install -r requirements.txt
+RUN python3 -m pip install --no-cache-dir -r requirements.txt
 ### remove unnecassary
 RUN rm -rf dist/
 RUN	rm -rf build/
@@ -23,9 +23,9 @@ RUN	find . -name '*.egg-link' -delete
 RUN	find . -name '*.pyc' -exec rm --force {} +
 RUN	find . -name '*.pyo' -exec rm --force {} +
 #### seorate requirements
-RUN python3 -m pip install --upgrade setuptools==67.6.0 wheel==0.40.0
+RUN python3 -m pip install --no-cache-dir --upgrade setuptools==67.6.0 wheel==0.40.0
 RUN	python3 -m setup -q sdist bdist_wheel
-RUN python3 -m pip install -q ./dist/cloudsplaining*.tar.gz
+RUN python3 -m pip install --no-cache-dir -q ./dist/cloudsplaining*.tar.gz
 ######## NPM installation
 RUN npm install
 


### PR DESCRIPTION
## What does this PR do?

using the "--no-cache-dir" flag in pip install, make sure downloaded packages by pip don't cache on the system. This is a best practice that makes sure to fetch from a repo instead of using a local cached one. Further, in the case of Docker Containers, by restricting caching, we can reduce image size. In terms of stats, it depends upon the number of python packages multiplied by their respective size. e.g for heavy packages with a lot of dependencies it reduces a lot by don't cache pip packages.

Further, more detailed information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6


## What gif best describes this PR or how it makes you feel?

[//]: # (Encouraged: Insert an appropriate gif/meme to brighten up your reviewer's day.)

## Completion checklist


- [ ] Additions and changes have unit tests
- [ ] The pull request has been appropriately labeled using the provided PR labels
- [ ] GitHub actions automation is passing (`make test`, `make lint`, `make security-test`, `make test-js`)
- [ ] If the UI contents or JavaScript files have been modified, generate a new example report:

```bash
# Generate the updated Javascript bundle
make build-js

# Generate the example report
make generate-report
```

