### PR TITLE
docs: Update documentation to reflect current features #178

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -12,7 +12,7 @@ build:
     pre_create_environment:
       - asdf plugin add uv
       - asdf install uv latest:0.10
-      - asdf global uv latest
+      - asdf global uv latest:0.10
     create_environment:
       - uv venv "${READTHEDOCS_VIRTUALENV_PATH}"
     install:

--- a/README.md
+++ b/README.md
@@ -27,13 +27,14 @@ For full documentation, please visit the [project on ReadTheDocs](https://clouds
 
 ## Overview
 
-Cloudsplaining identifies violations of least privilege in AWS IAM policies and generates a pretty HTML report with a triage worksheet. It can scan all the policies in your AWS account or it can scan a single policy file.
+Cloudsplaining identifies violations of least privilege in AWS IAM policies and generates a pretty HTML report. It can scan all the policies in your AWS account, across multiple AWS accounts, or it can scan a single policy file.
 
 It helps to identify IAM actions that do not leverage resource constraints. It also helps prioritize the remediation process by flagging IAM policies that present the following risks to the AWS account in question without restriction:
-* Data Exfiltration (`s3:GetObject`, `ssm:GetParameter`, `secretsmanager:GetSecretValue`)
-* Infrastructure Modification
-* Resource Exposure (the ability to modify resource-based policies)
-* Privilege Escalation (based on Rhino Security Labs research)
+* [Data Exfiltration](https://cloudsplaining.readthedocs.io/en/latest/glossary/data-exfiltration/) (`s3:GetObject`, `ssm:GetParameter`, `secretsmanager:GetSecretValue`)
+* [Infrastructure Modification](https://cloudsplaining.readthedocs.io/en/latest/glossary/infrastructure-modification/)
+* [Resource Exposure](https://cloudsplaining.readthedocs.io/en/latest/glossary/resource-exposure/) (the ability to modify resource-based policies)
+* [Privilege Escalation](https://cloudsplaining.readthedocs.io/en/latest/glossary/privilege-escalation/) (based on Rhino Security Labs research)
+* [Credentials Exposure](https://cloudsplaining.readthedocs.io/en/latest/glossary/credentials-exposure/)
 
 Cloudsplaining also identifies IAM Roles that can be assumed by AWS Compute Services (such as EC2, ECS, EKS, or Lambda), as they can present greater risk than user-defined roles - especially if the AWS Compute service is on an instance that is directly or indirectly exposed to the internet. Flagging these roles is particularly useful to penetration testers (or attackers) under certain scenarios. For example, if an attacker obtains privileges to execute [ssm:SendCommand](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_SendCommand.html) and there are privileged EC2 instances with the SSM agent installed, they can effectively have the privileges of those EC2 instances. Remote Code Execution via AWS Systems Manager Agent was already a known escalation/exploitation path, but Cloudsplaining can make the process of identifying theses cases easier. See the [sample report](https://opensource.salesforce.com/cloudsplaining/#executive-summary) for some examples.
 
@@ -80,7 +81,7 @@ Policy Sentry [makes it really easy to do this](https://github.com/salesforce/po
 
 That's why we wrote Cloudsplaining.
 
-Cloudsplaining identifies violations of least privilege in AWS IAM policies and generates a pretty HTML report with a triage worksheet. It can scan all the policies in your AWS account or it can scan a single policy file.
+Cloudsplaining identifies violations of least privilege in AWS IAM policies and generates a pretty HTML report. It can scan all the policies in your AWS account, across multiple AWS accounts, or it can scan a single policy file.
 
 ## Installation
 

--- a/cloudsplaining/bin/cli.py
+++ b/cloudsplaining/bin/cli.py
@@ -5,7 +5,7 @@
 # For full license text, see the LICENSE file in the repo root
 # or https://opensource.org/licenses/BSD-3-Clause
 """
-Cloudsplaining is an AWS IAM Assessment tool that identifies violations of least privilege and generates a risk-prioritized HTML report with a triage worksheet.
+Cloudsplaining is an AWS IAM Assessment tool that identifies violations of least privilege and generates a risk-prioritized HTML report.
 """
 
 import click
@@ -18,7 +18,7 @@ from cloudsplaining.bin.version import __version__
 @click.version_option(version=__version__)
 def cloudsplaining() -> None:
     """
-    Cloudsplaining is an AWS IAM Assessment tool that identifies violations of least privilege and generates a risk-prioritized HTML report with a triage worksheet.
+    Cloudsplaining is an AWS IAM Assessment tool that identifies violations of least privilege and generates a risk-prioritized HTML report.
     """
 
 
@@ -32,7 +32,7 @@ cloudsplaining.add_command(command.download.download)
 
 
 def main() -> None:
-    """Cloudsplaining is an AWS IAM Assessment tool that identifies violations of least privilege and generates a risk-prioritized HTML report with a triage worksheet."""
+    """Cloudsplaining is an AWS IAM Assessment tool that identifies violations of least privilege and generates a risk-prioritized HTML report."""
     cloudsplaining()
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Cloudsplaining
 
-[Cloudsplaining](https://github.com/salesforce/cloudsplaining) identifies violations of least privilege in AWS IAM policies and generates a pretty HTML report with a triage worksheet. It can scan all the policies in your AWS account or it can scan a single policy file.
+[Cloudsplaining](https://github.com/salesforce/cloudsplaining) identifies violations of least privilege in AWS IAM policies and generates a pretty HTML report. It can scan all the policies in your AWS account, across multiple AWS accounts, or it can scan a single policy file.
 
 ![](_images/cloudsplaining-report.gif)
 
@@ -8,7 +8,7 @@
 
 * `cloudsplaining download` - Download IAM authorization details for an entire AWS account.
 * `cloudsplaining create-exclusions-file` - Create an exclusions file to filter out false positives specific to your context.
-* `cloudsplaining scan` - Scan the IAM authorization details file; generate an HTML report and a triage worksheet.
+* `cloudsplaining scan` - Scan the IAM authorization details file; generate an HTML report.
 * `cloudsplaining scan-policy-file` - Scan a single IAM policy file
 * `cloudsplaining --help` - Print help messages and exit.
 

--- a/docs/user-guide/overview.md
+++ b/docs/user-guide/overview.md
@@ -1,12 +1,13 @@
 # Overview
 
-[Cloudsplaining](https://github.com/salesforce/cloudsplaining) identifies violations of least privilege in AWS IAM policies and generates a pretty HTML report with a triage worksheet. It can scan all the policies in your AWS account or it can scan a single policy file.
+[Cloudsplaining](https://github.com/salesforce/cloudsplaining) identifies violations of least privilege in AWS IAM policies and generates a pretty HTML report. It can scan all the policies in your AWS account, across multiple AWS accounts, or it can scan a single policy file.
 
 It helps to identify IAM actions that do not leverage resource constraints and thus can present the following risks to the AWS account in question without restriction:
-* Data Exfiltration (`s3:GetObject`, `ssm:GetParameter`, `secretsmanager:GetSecretValue`)
-* Infrastructure Modification
-* Resource Exposure (the ability to modify resource-based policies)
-* Privilege Escalation (based on Rhino Security Labs research)
+* [Data Exfiltration](../glossary/data-exfiltration.md) (`s3:GetObject`, `ssm:GetParameter`, `secretsmanager:GetSecretValue`)
+* [Infrastructure Modification](../glossary/infrastructure-modification.md)
+* [Resource Exposure](../glossary/resource-exposure.md) (the ability to modify resource-based policies)
+* [Privilege Escalation](../glossary/privilege-escalation.md) (based on Rhino Security Labs research)
+* [Credentials Exposure](../glossary/credentials-exposure.md)
 
 You can also specify a custom exclusions file to filter out results that are False Positives for various reasons. For example, User Policies are permissive by design, whereas System roles are generally more restrictive. You might also have exclusions that are specific to your organization's multi-account strategy or AWS application architecture.
 
@@ -18,4 +19,4 @@ You can also specify a custom exclusions file to filter out results that are Fal
     - `cloudsplaining create-exclusions-file --output-file exclusions.yml`
 * Scan the Account Authorization details
     - `cloudsplaining scan --input-file default-account-details.json --exclusions-file exclusions.yml`
-    - This generates three files: (1) The single-file HTML report, (2) The triage CSV worksheet, and (3) The raw JSON data file
+    - This generates two files: (1) The single-file HTML report, and (2) The raw JSON data file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ requires = ["uv_build~=0.10.0"]
 build-backend = "uv_build"
 
 [tool.uv]
-required-version = "~=0.10.0"
+required-version = ">=0.10.0"
 
 [tool.uv.build-backend]
 module-name = "cloudsplaining"


### PR DESCRIPTION
Resolves #178
This pull request removes mentions of 'triage worksheet' which is no longer generated. It also mentions that Cloudsplaining can scan across multiple AWS accounts, adds Credentials Exposure to the list of risks, and adds ReadTheDocs glossary links for the risk definitions.