### PR TITLE
fix: detect AttachRolePolicy/PutRolePolicy/UpdateAssumeRolePolicy privesc without sts:AssumeRole

### DIFF
--- a/cloudsplaining/shared/constants.py
+++ b/cloudsplaining/shared/constants.py
@@ -118,12 +118,12 @@ PRIVILEGE_ESCALATION_METHODS = {
     "SetExistingDefaultPolicyVersion": ["iam:setdefaultpolicyversion"],
     "AttachUserPolicy": ["iam:attachuserpolicy"],
     "AttachGroupPolicy": ["iam:attachgrouppolicy"],
-    "AttachRolePolicy": ["iam:attachrolepolicy", "sts:assumerole"],
+    "AttachRolePolicy": ["iam:attachrolepolicy"],
     "PutUserPolicy": ["iam:putuserpolicy"],
     "PutGroupPolicy": ["iam:putgrouppolicy"],
-    "PutRolePolicy": ["iam:putrolepolicy", "sts:assumerole"],
+    "PutRolePolicy": ["iam:putrolepolicy"],
     # 3. Updating an AssumeRolePolicy
-    "UpdateRolePolicyToAssumeIt": ["iam:updateassumerolepolicy", "sts:assumerole"],
+    "UpdateRolePolicyToAssumeIt": ["iam:updateassumerolepolicy"],
     # 4. iam:PassRole:*
     "CreateEC2WithExistingIP": ["iam:passrole", "ec2:runinstances"],
     "PassExistingRoleToNewLambdaThenInvoke": [

--- a/test/command/test_scan_policy_file.py
+++ b/test/command/test_scan_policy_file.py
@@ -295,7 +295,7 @@ class PolicyFileTestCase(unittest.TestCase):
                 "severity": "high",
                 "description": '<p>These policies allow a combination of IAM actions that allow a principal with these permissions to escalate their privileges - for example, by creating an access key for another IAM user, or modifying their own permissions. This research was pioneered by Spencer Gietzen at Rhino Security Labs.  Remediation guidance can be found <a href="https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/">here</a>.</p>',
                 "findings": [
-                    {"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy", "sts:assumerole"]}
+                    {"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy"]}
                 ],
             },
             "ResourceExposure": {

--- a/test/command/test_scan_policy_file.py
+++ b/test/command/test_scan_policy_file.py
@@ -294,9 +294,7 @@ class PolicyFileTestCase(unittest.TestCase):
             "PrivilegeEscalation": {
                 "severity": "high",
                 "description": '<p>These policies allow a combination of IAM actions that allow a principal with these permissions to escalate their privileges - for example, by creating an access key for another IAM user, or modifying their own permissions. This research was pioneered by Spencer Gietzen at Rhino Security Labs.  Remediation guidance can be found <a href="https://rhinosecuritylabs.com/aws/aws-privilege-escalation-methods-mitigation/">here</a>.</p>',
-                "findings": [
-                    {"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy"]}
-                ],
+                "findings": [{"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy"]}],
             },
             "ResourceExposure": {
                 "severity": "high",

--- a/test/scanning/test_authorization_details.py
+++ b/test/scanning/test_authorization_details.py
@@ -124,7 +124,7 @@ class TestAuthorizationFileDetails(unittest.TestCase):
         )
         self.assertListEqual(
             authz_details.policies.policy_details[0].policy_document.allows_privilege_escalation,
-            [{"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy", "sts:assumerole"]}],
+            [{"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy"]}],
         )
         self.assertListEqual(
             authz_details.policies.policy_details[0].policy_document.allows_data_exfiltration_actions, ["s3:GetObject"]

--- a/test/scanning/test_policy_document.py
+++ b/test/scanning/test_policy_document.py
@@ -400,9 +400,7 @@ class TestPolicyDocument(unittest.TestCase):
             ],
         }
         policy_document = PolicyDocument(test_policy, flag_resource_arn_statements=True)
-        expected_result = [
-            {"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy"]}
-        ]
+        expected_result = [{"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy"]}]
         self.assertDictEqual(policy_document.allows_privilege_escalation[0], expected_result[0])
         policy_document = PolicyDocument(test_policy, flag_resource_arn_statements=False)
         self.assertListEqual(policy_document.allows_privilege_escalation, [])
@@ -487,9 +485,7 @@ class TestPolicyDocument(unittest.TestCase):
         # GH-580: iam:AttachRolePolicy on * is an escalation even without sts:AssumeRole
         test_policy = {
             "Version": "2012-10-17",
-            "Statement": [
-                {"Effect": "Allow", "Action": ["iam:AttachRolePolicy"], "Resource": "*"}
-            ],
+            "Statement": [{"Effect": "Allow", "Action": ["iam:AttachRolePolicy"], "Resource": "*"}],
         }
         policy_document = PolicyDocument(test_policy)
         self.assertListEqual(

--- a/test/scanning/test_policy_document.py
+++ b/test/scanning/test_policy_document.py
@@ -401,7 +401,7 @@ class TestPolicyDocument(unittest.TestCase):
         }
         policy_document = PolicyDocument(test_policy, flag_resource_arn_statements=True)
         expected_result = [
-            {"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy", "sts:assumerole"]}
+            {"type": "UpdateRolePolicyToAssumeIt", "actions": ["iam:updateassumerolepolicy"]}
         ]
         self.assertDictEqual(policy_document.allows_privilege_escalation[0], expected_result[0])
         policy_document = PolicyDocument(test_policy, flag_resource_arn_statements=False)
@@ -482,6 +482,20 @@ class TestPolicyDocument(unittest.TestCase):
         self.assertListEqual(policy_document.infrastructure_modification, ["ec2:AuthorizeSecurityGroupIngress"])
         policy_document = PolicyDocument(test_policy, flag_resource_arn_statements=False)
         self.assertListEqual(policy_document.infrastructure_modification, [])
+
+    def test_allows_privilege_escalation_attach_role_policy_without_assume(self):
+        # GH-580: iam:AttachRolePolicy on * is an escalation even without sts:AssumeRole
+        test_policy = {
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": ["iam:AttachRolePolicy"], "Resource": "*"}
+            ],
+        }
+        policy_document = PolicyDocument(test_policy)
+        self.assertListEqual(
+            policy_document.allows_privilege_escalation,
+            [{"type": "AttachRolePolicy", "actions": ["iam:attachrolepolicy"]}],
+        )
 
     def test_gh_278_all_issue_types_respect_conditions_on_policy(self):
         test_policy_all_issues_no_conditions = {


### PR DESCRIPTION
## Summary

Three methods in `PRIVILEGE_ESCALATION_METHODS` bundled `sts:assumerole` as a required action, producing **false negatives**: a policy granting `iam:AttachRolePolicy` (or `iam:PutRolePolicy` / `iam:UpdateAssumeRolePolicy`) on `*` *without* `sts:AssumeRole` was not flagged — even though it can attach `AdministratorAccess` to any role.

This relaxes the three entries to the IAM write alone. The existing `+ sts:AssumeRole` cases still fire (the relaxed action set is a subset of them), so **nothing previously detected is lost — only coverage is added**. Aligns with DataDog/pathfinding.cloud `iam-005`/`iam-009`/`iam-012` and peer tools (PMapper, Prowler).

## Changes
- `cloudsplaining/shared/constants.py`: drop `sts:assumerole` from `AttachRolePolicy`, `PutRolePolicy`, `UpdateRolePolicyToAssumeIt`.
- New TDD test proving `iam:AttachRolePolicy` alone is flagged.
- Update 3 existing assertions that expected the bundled action list.

## Testing
- `just unit-tests` — 94 passed
- `just type-check` — clean
- `just test-js` — 43 passing

Closes #580