### PR TITLE
Sort principals alphabetically by name instead of ID (resolves #238)

### DIFF
--- a/cloudsplaining/output/src/test/principals-test.js
+++ b/cloudsplaining/output/src/test/principals-test.js
@@ -29,14 +29,24 @@ it("principals.getPrincipalMetadata: should return principal object", function (
 
 it("principals.getPrincipalIds: should return a list of principal IDs for a given principal type", function () {
     var result = principals.getPrincipalIds(iam_data, "User");
-    // The dataset now contains many more users. Assert the known teaching IDs are present.
+    // The dataset now contains many more users. Assert the known teaching IDs are present...
     var knownIds = ["ASIAZZUSERZZPLACEHOLDER", "obama", "biden"]
     assert(result != null);
     assert(result.length >= 3, `Expected at least 3 user IDs, got ${result.length}`)
     knownIds.forEach(function(id) {
       assert(result.includes(id), `Expected user ID ${id} to be present in results`)
     })
-    console.log(`User IDs includes teaching entities: ${JSON.stringify(result)}`);
+    // ...and that IDs are ordered alphabetically by their principal NAME (#238), not by the
+    // opaque ID. Re-derive names in the returned order and assert they are non-decreasing,
+    // mirroring getPrincipalIds' comparator (case-insensitive name, with ID fallback).
+    var namesInReturnedOrder = result.map(function (id) {
+        return ((iam_data["users"][id] && iam_data["users"][id].name) || id).toLowerCase();
+    });
+    var sortedNames = namesInReturnedOrder.slice().sort(function (a, b) {
+        return a.localeCompare(b);
+    });
+    assert.deepStrictEqual(namesInReturnedOrder, sortedNames, "Expected user IDs to be ordered alphabetically by name");
+    console.log(`User IDs ordered by name: ${JSON.stringify(result)}`);
 });
 
 it("principals.getPrincipalNames: should return a list of principal names for a given principal type", function () {

--- a/cloudsplaining/output/src/util/principals.js
+++ b/cloudsplaining/output/src/util/principals.js
@@ -45,18 +45,28 @@ function getPrincipalNames(iam_data, principalType) {
 function getPrincipalIds(iam_data, principalType) {
     let result;
     if (principalType.toLowerCase() === "role") {
-        result = Object.keys(iam_data["roles"])
-        return result.sort();
+        result = Object.keys(iam_data["roles"]);
+        return result.sort(function(a, b) {
+            let nameA = (iam_data["roles"][a].name || a).toLowerCase();
+            let nameB = (iam_data["roles"][b].name || b).toLowerCase();
+            return nameA.localeCompare(nameB);
+        });
     }
     if (principalType.toLowerCase() === "group") {
         result = Object.keys(iam_data["groups"]);
-        result.sort();
-        return result
+        return result.sort(function(a, b) {
+            let nameA = (iam_data["groups"][a].name || a).toLowerCase();
+            let nameB = (iam_data["groups"][b].name || b).toLowerCase();
+            return nameA.localeCompare(nameB);
+        });
     }
     if (principalType.toLowerCase() === "user") {
         result = Object.keys(iam_data["users"]);
-        result.sort();
-        return result
+        return result.sort(function(a, b) {
+            let nameA = (iam_data["users"][a].name || a).toLowerCase();
+            let nameB = (iam_data["users"][b].name || b).toLowerCase();
+            return nameA.localeCompare(nameB);
+        });
     }
 }
 


### PR DESCRIPTION
Sorts the principals page alphabetically by **name** instead of by the opaque IAM ID. Resolves #238.

`getPrincipalIds()` previously returned `Object.keys(...).sort()` — i.e. sorted by the underlying IAM ID (`AROA…`/`AIDA…`), which renders as an apparently-random order in the UI. It now sorts by each principal's `.name` (case-insensitive `localeCompare`, falling back to the ID when a name is absent).

### Credit / provenance
Supersedes #557 by @nikhil6393 — their commit and authorship are preserved here. I rebased it onto current `master` and made two maintainer adjustments:

1. **Updated the test for the enriched dataset.** Master's example data was expanded (#583) and `principals-test.js` now uses membership assertions. Rather than reverting to the old 2-element exact list, this keeps the membership assertion **and adds a real ordering check**: it re-derives the principal names in the returned order and asserts they're non-decreasing (mirroring the implementation's comparator). That fails on the old ID-sort and passes on the new name-sort, so it actually covers #238.
2. **Dropped the `pyproject.toml` uv-version hunk.** It relaxed `~=0.10.0` → `>=0.10.0`, but `master` is already at `>=0.11.0`, so it's obsolete.

### Notes
- `getPrincipalNames()` still uses a default (case-sensitive) sort. Left as-is to keep this change focused on #238; worth aligning to the same case-insensitive comparator in a follow-up so the names list and IDs list order identically.

### Tests
`just test-js` → 47 passing, including `getPrincipalIds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
