### PR TITLE
docs: remove stale triage CSV worksheet references

### DIFF
--- a/docs/appendices/comparison-to-other-tools.md
+++ b/docs/appendices/comparison-to-other-tools.md
@@ -6,7 +6,7 @@ In short, its differentiating factors are:
 
 * Identifying lack of resource ARN constraints for modify-level policies, as well as other risk categories
 * Digestible presentation of over-privileged IAM policies in a human readable HTML report
-* Workflow is tailor-made for quick assessment, team review, and ticket-opening (as shown in the Triage CSV worksheet)
+* Workflow is tailor-made for quick assessment, team review, and ticket-opening (as shown in the triage guidance)
 * The detailed triage, remediation, and validation guidance allows technical individuals who are not experts in AWS IAM to handle most issues with account owner teams when triaging and identifying exclusions.
 * If you've ever wondered "does this role *truly deserve* to have these privileges or can we scope the permissions down to reduce blast radius in the case of a breach?" Cloudsplaining is tailor-made for addressing this issue.
 

--- a/docs/report/triage.md
+++ b/docs/report/triage.md
@@ -30,20 +30,20 @@ To recap: you've followed these steps to generate this report:
     - `cloudsplaining create-exclusions-file --output-file exclusions.yml`
 * Scanned the Account authorization details
     - `cloudsplaining scan --input-file default-account-details.json --exclusions-file exclusions.yml`
-    - This generates three files: (1) The single-file HTML report, (2) The triage CSV worksheet, and (3) The raw JSON data file
+    - This generates two files: (1) The single-file HTML report, and (2) The raw JSON data file
 
 ## Triaging workflow
 
 An assessor can follow this general workflow:
 
 * Open a ticket in your organization's project management tool of choice (for example, JIRA or Salesforce) in the AWS account owner's project
-* Attach the HTML report, JSON Data file, and CSV worksheet
-* Ask the service/account owner team to fill out the Triage worksheet
+* Attach the HTML report and the raw JSON data file
+* Ask the service/account owner team to review the findings and provide a justification for each
 
-When you ask the service/account owner team to fill out the Triage CSV worksheet, you can use some text like the following:
+When you ask the service/account owner team to review the findings, you can use some text like the following:
 
 > As part of our security assessment, our team ran Cloudsplaining on your AWS account. Cloudsplaining maps out the IAM risk landscape in a report, identifies where resource ARN constraints are not in use, and identifies other risks in IAM policies like Privilege Escalation, Data Exfiltration, and Resource Exposure/Permissions management. Remediating these issues, where applicable, will help to limit the blast radius in the case of compromised AWS credentials.
-> We request that you review the HTML report and fill out the "Justification" field in the Triage worksheet. Based on the corresponding details in the HTML report, provide either (1) A justification on why the result is a False Positive, or (2) Identify that it is a legitimate finding.
+> We request that you review the HTML report and, for each finding, provide either (1) A justification on why the result is a False Positive, or (2) Identification that it is a legitimate finding.
 
 
 ## Triaging Considerations


### PR DESCRIPTION
## What

Removes stale references to the **triage CSV worksheet** from the docs. The `scan` command no longer emits a separate CSV worksheet — it produces the single-file HTML report and the raw JSON data file (verified against a real scan). The HTML report contains read-only **triage guidance**, not a fillable worksheet.

- `docs/report/triage.md`: "three files" → "two files"; the triage workflow now asks reviewers to justify findings against the HTML report directly instead of filling out a CSV worksheet.
- `docs/appendices/comparison-to-other-tools.md`: "(as shown in the Triage CSV worksheet)" → "(as shown in the triage guidance)".

## Context

Follows the docs modernization in #595 (which removed "triage worksheet" wording from the README/overview). This finishes that cleanup for the dedicated triage page.

## Known follow-up (out of scope — needs a JS rebuild)

The **in-report** guidance source, `cloudsplaining/output/src/assets/2-triage-guidance.md`, carries the same stale CSV-worksheet wording, so the rendered HTML report still tells users to "fill out the Triage CSV worksheet." Fixing that means editing the asset and rebuilding the committed Vue bundle (`just build-js`), which is a larger, non-docs change — worth its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
