### PR TITLE
Add GUSINFO to CODEOWNERS for OSPO compliance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,6 +192,8 @@ target/
 .python-version
 
 # pipenv
+#   This project uses uv (see pyproject.toml); Pipfile is a local convenience file, not tracked.
+Pipfile
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
 #   However, in case of collaboration, if having platform-specific dependencies or dependencies
 #   having no cross-platform support, pipenv may install dependencies that don't work, or not

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,3 @@
 # Comment line immediately above ownership line is reserved for related gus information. Please be careful while editing.
 #ECCN:Open Source
+#GUSINFO:IAM - Privileged Access Management,PAM


### PR DESCRIPTION
## Summary
- Adds the required `#GUSINFO:` line to `CODEOWNERS`, which was previously missing the GUS Scrum Team and Product Tag.
- Resolves the OSPO compliance issue flagged for this repo: *missing GUS Scrum Team; missing GUS Product Tag*.
- Values reference our own active GUS records (not the disallowed `Open Source` / `Open Source Workflow` placeholders):
  - **Scrum Team:** `IAM - Privileged Access Management`
  - **Product Tag:** `PAM`
- Format follows the `salesforce/oss-template` `CODEOWNERS` example: left-aligned `#GUSINFO:<Scrum Team>,<Product Tag>`, placed immediately after the `#ECCN:` line.
- Also gitignores the local `Pipfile` (this project uses uv for dependency management).

## Test Plan
- [x] `#GUSINFO:` line is left-aligned and matches the oss-template format
- [x] Scrum Team and Product Tag correspond to active GUS records
- [ ] OSPO compliance check passes for this repo